### PR TITLE
Solution/workaround? :-) for: MODCLUSTER-339

### DIFF
--- a/native/mod_manager/mod_manager.c
+++ b/native/mod_manager/mod_manager.c
@@ -903,15 +903,17 @@ static char * process_config(request_rec *r, char **ptr, int *errtype)
             /* Removes %zone from an address */
             char *p_read = ptr[i+1], *p_write = ptr[i+1];
             int flag = 0;
-            while (*p_read) {
-                *p_write = *p_read++;
-                if ((*p_write == '%' || flag) && *p_write != ']') {
-                    flag = 1;
-                } else {
-                    p_write++;
+            if (*p_read == '[') {
+                while (*p_read) {
+                    *p_write = *p_read++;
+                    if ((*p_write == '%' || flag) && *p_write != ']') {
+                        flag = 1;
+                    } else {
+                        p_write++;
+                    }
                 }
+                *p_write = '\0';
             }
-            *p_write = '\0';
 
             strcpy(nodeinfo.mess.Host, ptr[i+1]);
         }


### PR DESCRIPTION
As I stated in my [comment on MODCLUSTER-339](http://goo.gl/3rBGc), I don't believe we actually need zone id in CONFIG message from our workers. At the moment, I am not sure how to make workers _not_ to send e.g. %2 appended to their IPv6 addresses, so I propose removing it on the balancer side.

I tested the code with [test_remove_zones.c](https://gist.github.com/Karm/5645769). Furthermore, I executed tests with a patched mod_manager.so on IPv4 and IPv6 on RHEL6.

I am still struggling with mod_cluster build on Solaris...
CFLAGS='-m64' apparently is not enough to force it to produce a proper sparc64 binary :-(  Ending up with a wrong ELF class: ELFCLASS32. I will comment on this post as soon as I make it.

NOTE: If it looks like a workaround to you, and possibly even an unfortunately placed one, scream.
