### PR TITLE
Arrange the test logic so that it "binds" to an interface that is up/running

### DIFF
--- a/core/src/test/java/org/jboss/modcluster/advertise/AdvertiseListenerImplTestCase.java
+++ b/core/src/test/java/org/jboss/modcluster/advertise/AdvertiseListenerImplTestCase.java
@@ -120,6 +120,12 @@ public class AdvertiseListenerImplTestCase {
         byte[] buf = data.toString().getBytes();
         DatagramPacket packet = new DatagramPacket(buf, buf.length, this.groupAddress, ADVERTISE_PORT);
 
+        try {
+            InetAddress socketInterface = InetAddress.getLocalHost();
+            this.socket.setInterface(socketInterface);
+        } catch (Exception ex) {
+            ; // Ignore it
+        }
         this.socket.send(packet);
 
         try {

--- a/core/src/test/java/org/jboss/modcluster/advertise/MulticastSocketFactoryImplTestCase.java
+++ b/core/src/test/java/org/jboss/modcluster/advertise/MulticastSocketFactoryImplTestCase.java
@@ -100,6 +100,13 @@ public class MulticastSocketFactoryImplTestCase {
             byte[] buffer = data.getBytes();
             DatagramPacket packet = new DatagramPacket(buffer, buffer.length, sendAddress, PORT);
 
+            try {
+                InetAddress socketInterface = InetAddress.getLocalHost();
+                sendSocket.setInterface(socketInterface);
+            } catch (Exception ex) {
+                ; // Ignore it
+            }
+
             sendSocket.send(packet);
 
             try {


### PR DESCRIPTION
In fact on macosx without the patch I have:
+++
Tests in error: 
  testBasicOperation(org.jboss.modcluster.advertise.AdvertiseListenerImplTestCase): Can't assign requested address
  testMulticastSocketNoCrossTalk(org.jboss.modcluster.advertise.MulticastSocketFactoryImplTestCase): Can't assign requested address
+++
/sbin/ifconfig shows:
macosx:mod_cluster jfclere$ /sbin/ifconfig
lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 16384
    inet6 ::1 prefixlen 128 
    inet6 fe80::1%lo0 prefixlen 64 scopeid 0x1 
    inet 127.0.0.1 netmask 0xff000000 
gif0: flags=8010<POINTOPOINT,MULTICAST> mtu 1280
stf0: flags=0<> mtu 1280
fw0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 2030
    lladdr 00:19:e3:ff:fe:2e:97:00 
    media: autoselect <full-duplex>
    status: inactive
en1: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
    ether 00:19:e3:06:ce:3f 
    media: autoselect (<unknown type>)
    status: inactive
en0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
    ether 00:17:f2:cc:ea:34 
    inet6 fe80::217:f2ff:fecc:ea34%en0 prefixlen 64 scopeid 0x6 
    inet 10.33.144.4 netmask 0xffffff00 broadcast 10.33.144.255
    media: autoselect (10baseT/UTP <half-duplex>)
    status: active
vboxnet0: flags=8842<BROADCAST,RUNNING,SIMPLEX,MULTICAST> mtu 1500
    ether 0a:00:27:00:00:00 
en2: flags=8963<UP,BROADCAST,SMART,RUNNING,PROMISC,SIMPLEX,MULTICAST> mtu 1500
    ether 00:1c:42:00:00:08 
    inet6 fe80::21c:42ff:fe00:8%en2 prefixlen 64 scopeid 0x8 
    inet 10.211.55.2 netmask 0xffffff00 broadcast 10.211.55.255
    media: autoselect
    status: active
en3: flags=8963<UP,BROADCAST,SMART,RUNNING,PROMISC,SIMPLEX,MULTICAST> mtu 1500
    ether 00:1c:42:00:00:09 
    inet6 fe80::21c:42ff:fe00:9%en3 prefixlen 64 scopeid 0x9 
    inet 10.37.129.2 netmask 0xffffff00 broadcast 10.37.129.255
    media: autoselect
    status: active
+++
without the patch it seems it uses a wrong interface
