### PR TITLE
Fails to build with error 

### DIFF
--- a/sar/pom.xml
+++ b/sar/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.mod_cluster</groupId>
         <artifactId>mod_cluster-parent</artifactId>
-        <version>1.2.5.Final-SNAPSHOT</version>
+        <version>1.2.4.Final</version>
         <relativePath>..</relativePath>
     </parent>
   


### PR DESCRIPTION
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]
[ERROR]   The project org.jboss.mod_cluster:mod_cluster-sar:1.2.3.Beta1-SNAPSHOT
 (C:\mod_cluster-1.2.4.Final\sar\pom.xml) has 1 error
[ERROR]     Non-resolvable parent POM: Could not find artifact org.jboss.mod_clu
ster:mod_cluster-parent:pom:1.2.3.Beta1-SNAPSHOT and 'parent.relativePath' point
s at wrong local POM @ line 4, column 13 -> [Help 2]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e swit
ch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
