### PR TITLE
[MODCLUSTER-322] Using AverageSystemLoadMetric can improperly cause a Load Factor of 0

### DIFF
--- a/src/main/java/org/jboss/modcluster/load/metric/impl/AverageSystemLoadMetric.java
+++ b/src/main/java/org/jboss/modcluster/load/metric/impl/AverageSystemLoadMetric.java
@@ -38,6 +38,7 @@ import org.jboss.logging.Logger;
 public class AverageSystemLoadMetric extends SourcedLoadMetric<MBeanLoadContext>
 {
    public static final String SYSTEM_LOAD_AVERAGE = "SystemLoadAverage";
+   public static final String AVAILABLE_PROCESSORS = "AvailableProcessors";
    
    private Logger logger = Logger.getLogger(this.getClass());
    
@@ -59,7 +60,7 @@ public class AverageSystemLoadMetric extends SourcedLoadMetric<MBeanLoadContext>
    {
       try
       {
-         return context.getAttribute(SYSTEM_LOAD_AVERAGE, Double.class).doubleValue();
+         return context.getAttribute(SYSTEM_LOAD_AVERAGE, Double.class).doubleValue() / context.getAttribute(AVAILABLE_PROCESSORS, Integer.class).intValue();
       }
       catch (AttributeNotFoundException e)
       {

--- a/src/test/java/org/jboss/modcluster/load/metric/AverageSystemLoadMetricTestCase.java
+++ b/src/test/java/org/jboss/modcluster/load/metric/AverageSystemLoadMetricTestCase.java
@@ -60,7 +60,8 @@ public class AverageSystemLoadMetricTestCase
    @Test
    public void getLoad() throws Exception
    {
-      EasyMock.expect(this.server.getAttribute(this.name, AverageSystemLoadMetric.SYSTEM_LOAD_AVERAGE)).andReturn(0.1);
+      EasyMock.expect(this.server.getAttribute(this.name, AverageSystemLoadMetric.SYSTEM_LOAD_AVERAGE)).andReturn(0.2);
+      EasyMock.expect(this.server.getAttribute(this.name, AverageSystemLoadMetric.AVAILABLE_PROCESSORS)).andReturn(2);
       
       EasyMock.replay(this.server);
       


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/MODCLUSTER-322
