### PR TITLE
[1.2.x] Revise MODCLUSTER-332 fix.

### DIFF
--- a/container-spi/src/main/java/org/jboss/modcluster/container/Connector.java
+++ b/container-spi/src/main/java/org/jboss/modcluster/container/Connector.java
@@ -55,10 +55,11 @@ public interface Connector {
          * 
          * @see java.lang.Enum#toString()
          */
+        @Override
         public String toString() {
             return this.name().toLowerCase();
         }
-    };
+    }
 
     /**
      * Indicates whether the endpoint of this connector uses a reverse connection to httpd. A reverse connection uses a normal

--- a/container-spi/src/main/java/org/jboss/modcluster/container/Engine.java
+++ b/container-spi/src/main/java/org/jboss/modcluster/container/Engine.java
@@ -104,10 +104,4 @@ public interface Engine {
      * @return the default host
      */
     String getDefaultHost();
-    
-    /**
-     * Returns the delay between the invocation of the backgroundProcess method.
-     * @return an int
-     */
-    int getBackgroundProcessorDelay();
 }

--- a/container/catalina/src/main/java/org/jboss/modcluster/container/catalina/CatalinaEngine.java
+++ b/container/catalina/src/main/java/org/jboss/modcluster/container/catalina/CatalinaEngine.java
@@ -174,9 +174,4 @@ public class CatalinaEngine implements Engine {
     public String toString() {
         return this.engine.getName();
     }
-
-	@Override
-	public int getBackgroundProcessorDelay() {
-		return this.engine.getBackgroundProcessorDelay();
-	}
 }


### PR DESCRIPTION
Remove unused Engine.getBackgroundProcessorDelay() method.
Replace ambiguous org.jboss.modcluster.container.catalina.WAITSTATUS system property with more intuitive org.jboss.modcluster.container.catalina.status-interval property.
Convert tab indentation to spaces.
