### PR TITLE
Fix MODCLUSTER-224 by sending a start message for a start event on a con...

### DIFF
--- a/container/catalina/src/main/java/org/jboss/modcluster/container/catalina/CatalinaEventHandlerAdapter.java
+++ b/container/catalina/src/main/java/org/jboss/modcluster/container/catalina/CatalinaEventHandlerAdapter.java
@@ -222,6 +222,9 @@ public class CatalinaEventHandlerAdapter implements CatalinaEventHandler {
                 if (this.init.get() && this.start.compareAndSet(false, true)) {
                     this.eventHandler.start(this.factory.createServer((Server) source));
                 }
+            } else if(source instanceof Context) {
+                // Start a webapp
+                this.eventHandler.start(this.factory.createContext((Context) source));
             }
         } else if (type.equals(Lifecycle.BEFORE_STOP_EVENT)) {
             if (source instanceof Context) {


### PR DESCRIPTION
When starting a webapp in the Tomcat Manager, it does not enable it in apache correctly. The code checked if the event was a Server event, but for this, it is a Context event. The code now will send a start event correctly for a context start.
