### PR TITLE
Modcluster 372

### DIFF
--- a/native/include/node.h
+++ b/native/include/node.h
@@ -158,6 +158,13 @@ int get_ids_used_node(mem_t *s, int *ids);
  */
 int get_max_size_node(mem_t *s);
 
+/*
+ * get the version of the table (each update of the table changes version)
+ * @param pointer to the shared table.
+ * @return version the actual version in the table.
+ */
+unsigned int get_version_node(mem_t *s);
+
 /**
  * attach to the shared node table
  * @param name of an existing shared table.
@@ -201,11 +208,11 @@ int (*get_max_size_node)();
  * check the nodes for modifications.
  * XXX: void *data is server_rec *s in fact.
  */
-apr_time_t (*worker_nodes_need_update)(void *data, apr_pool_t *pool);
+unsigned int (*worker_nodes_need_update)(void *data, apr_pool_t *pool);
 /*
  * mark that the worker node are now up to date.
  */
-int (*worker_nodes_are_updated)(void *data);
+int (*worker_nodes_are_updated)(void *data, unsigned int version);
 /*
  * Remove the node from shared memory (free the slotmem)
  */

--- a/native/include/slotmem.h
+++ b/native/include/slotmem.h
@@ -68,10 +68,11 @@ struct slotmem_storage_method {
  * @param s ap_slotmem_t to use.
  * @param funct callback function to call for each element.
  * @param data parameter for the callback function.
+ * @param new_version parameter to tell the version should be changed
  * @param pool is pool used to create scoreboard
  * @return APR_SUCCESS if all went well
  */
-apr_status_t (* ap_slotmem_do)(ap_slotmem_t *s, mc_slotmem_callback_fn_t *func, void *data, apr_pool_t *pool);
+apr_status_t (* ap_slotmem_do)(ap_slotmem_t *s, mc_slotmem_callback_fn_t *func, void *data, int new_version, apr_pool_t *pool);
 
 /**
  * create a new slotmem with each item size is item_size.
@@ -144,6 +145,12 @@ apr_status_t (* ap_slotmem_lock)(ap_slotmem_t *s);
  * @return APR_SUCCESS if all went well
  */
 apr_status_t (* ap_slotmem_unlock)(ap_slotmem_t *s);
+/**
+ * Return the version of the slotmem table.
+ * @param s ap_slotmem_t to use.
+ * @return value of the version. version increased each an element is modified.
+ */
+unsigned int (*ap_slotmem_get_version)(ap_slotmem_t *s);
 };
 
 typedef struct slotmem_storage_method slotmem_storage_method;

--- a/native/mod_manager/balancer.c
+++ b/native/mod_manager/balancer.c
@@ -96,7 +96,7 @@ apr_status_t insert_update_balancer(mem_t *s, balancerinfo_t *balancer)
 
     balancer->id = 0;
     s->storage->ap_slotmem_lock(s->slotmem);
-    rv = s->storage->ap_slotmem_do(s->slotmem, insert_update, &balancer, s->p);
+    rv = s->storage->ap_slotmem_do(s->slotmem, insert_update, &balancer, 1, s->p);
     if (balancer->id != 0 && rv == APR_SUCCESS) {
         s->storage->ap_slotmem_unlock(s->slotmem);
         return APR_SUCCESS; /* updated */
@@ -140,7 +140,7 @@ balancerinfo_t * read_balancer(mem_t *s, balancerinfo_t *balancer)
     if (balancer->id)
         rv = s->storage->ap_slotmem_mem(s->slotmem, balancer->id, (void **) &ou);
     else {
-        rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_balancer, &ou, s->p);
+        rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_balancer, &ou, 0, s->p);
     }
     if (rv == APR_SUCCESS)
         return ou;
@@ -172,7 +172,7 @@ apr_status_t remove_balancer(mem_t *s, balancerinfo_t *balancer)
         s->storage->ap_slotmem_free(s->slotmem, balancer->id, balancer);
     else {
         /* XXX: for the moment January 2007 ap_slotmem_free only uses ident to remove */
-        rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_balancer, &ou, s->p);
+        rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_balancer, &ou, 0, s->p);
         if (rv == APR_SUCCESS)
             rv = s->storage->ap_slotmem_free(s->slotmem, ou->id, balancer);
     }

--- a/native/mod_manager/context.c
+++ b/native/mod_manager/context.c
@@ -98,7 +98,7 @@ apr_status_t insert_update_context(mem_t *s, contextinfo_t *context)
 
     context->id = 0;
     s->storage->ap_slotmem_lock(s->slotmem);
-    rv = s->storage->ap_slotmem_do(s->slotmem, insert_update, &context, s->p);
+    rv = s->storage->ap_slotmem_do(s->slotmem, insert_update, &context, 1, s->p);
     if (context->id != 0 && rv == APR_SUCCESS) {
         s->storage->ap_slotmem_unlock(s->slotmem);
         return APR_SUCCESS; /* updated */
@@ -143,7 +143,7 @@ contextinfo_t * read_context(mem_t *s, contextinfo_t *context)
     if (context->id)
         rv = s->storage->ap_slotmem_mem(s->slotmem, context->id, (void **) &ou);
     else {
-        rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_context, &ou, s->p);
+        rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_context, &ou, 0, s->p);
     }
     if (rv == APR_SUCCESS)
         return ou;
@@ -175,7 +175,7 @@ apr_status_t remove_context(mem_t *s, contextinfo_t *context)
         s->storage->ap_slotmem_free(s->slotmem, context->id, context);
     else {
         /* XXX: for the moment January 2007 ap_slotmem_free only uses ident to remove */
-        rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_context, &ou, s->p);
+        rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_context, &ou, 0, s->p);
         if (rv == APR_SUCCESS)
             rv = s->storage->ap_slotmem_free(s->slotmem, ou->id, context);
     }

--- a/native/mod_manager/domain.c
+++ b/native/mod_manager/domain.c
@@ -96,7 +96,7 @@ apr_status_t insert_update_domain(mem_t *s, domaininfo_t *domain)
 
     domain->id = 0;
     s->storage->ap_slotmem_lock(s->slotmem);
-    rv = s->storage->ap_slotmem_do(s->slotmem, insert_update, &domain, s->p);
+    rv = s->storage->ap_slotmem_do(s->slotmem, insert_update, &domain, 1, s->p);
     if (domain->id != 0 && rv == APR_SUCCESS) {
          s->storage->ap_slotmem_unlock(s->slotmem);
         return APR_SUCCESS; /* updated */
@@ -140,7 +140,7 @@ domaininfo_t * read_domain(mem_t *s, domaininfo_t *domain)
     if (domain->id)
         rv = s->storage->ap_slotmem_mem(s->slotmem, domain->id, (void **) &ou);
     else {
-        rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_domain, &ou, s->p);
+        rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_domain, &ou, 0, s->p);
     }
     if (rv == APR_SUCCESS)
         return ou;
@@ -172,7 +172,7 @@ apr_status_t remove_domain(mem_t *s, domaininfo_t *domain)
         s->storage->ap_slotmem_free(s->slotmem, domain->id, domain);
     else {
         /* XXX: for the moment January 2007 ap_slotmem_free only uses ident to remove */
-        rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_domain, &ou, s->p);
+        rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_domain, &ou, 0, s->p);
         if (rv == APR_SUCCESS)
             rv = s->storage->ap_slotmem_free(s->slotmem, ou->id, domain);
     }
@@ -194,7 +194,7 @@ apr_status_t find_domain(mem_t *s, domaininfo_t **domain, const char *route, con
     strcpy(ou.JVMRoute, route);
     strcpy(ou.balancer, balancer);
     *domain = &ou;
-    rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_domain, domain, s->p);
+    rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_domain, domain, 0, s->p);
     return rv;
 }
 

--- a/native/mod_manager/host.c
+++ b/native/mod_manager/host.c
@@ -96,7 +96,7 @@ apr_status_t insert_update_host(mem_t *s, hostinfo_t *host)
 
     host->id = 0;
     s->storage->ap_slotmem_lock(s->slotmem);
-    rv = s->storage->ap_slotmem_do(s->slotmem, insert_update, &host, s->p);
+    rv = s->storage->ap_slotmem_do(s->slotmem, insert_update, &host, 1, s->p);
     if (host->id != 0 && rv == APR_SUCCESS) {
         s->storage->ap_slotmem_unlock(s->slotmem);
         return APR_SUCCESS; /* updated */
@@ -140,7 +140,7 @@ hostinfo_t * read_host(mem_t *s, hostinfo_t *host)
     if (host->id)
         rv = s->storage->ap_slotmem_mem(s->slotmem, host->id, (void **) &ou);
     else {
-        rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_host, &ou, s->p);
+        rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_host, &ou, 0, s->p);
     }
     if (rv == APR_SUCCESS)
         return ou;
@@ -172,7 +172,7 @@ apr_status_t remove_host(mem_t *s, hostinfo_t *host)
         s->storage->ap_slotmem_free(s->slotmem, host->id, host);
     else {
         /* XXX: for the moment January 2007 ap_slotmem_free only uses ident to remove */
-        rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_host, &ou, s->p);
+        rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_host, &ou, 0, s->p);
         if (rv == APR_SUCCESS)
             rv = s->storage->ap_slotmem_free(s->slotmem, ou->id, host);
     }

--- a/native/mod_manager/jgroupsid.c
+++ b/native/mod_manager/jgroupsid.c
@@ -95,7 +95,7 @@ apr_status_t insert_update_jgroupsid(mem_t *s, jgroupsidinfo_t *jgroupsid)
     int ident;
 
     jgroupsid->id = 0;
-    rv = s->storage->ap_slotmem_do(s->slotmem, insert_update, &jgroupsid, s->p);
+    rv = s->storage->ap_slotmem_do(s->slotmem, insert_update, &jgroupsid, 1, s->p);
     if (jgroupsid->id != 0 && rv == APR_SUCCESS) {
         return APR_SUCCESS; /* updated */
     }
@@ -136,7 +136,7 @@ jgroupsidinfo_t * read_jgroupsid(mem_t *s, jgroupsidinfo_t *jgroupsid)
     if (jgroupsid->id)
         rv = s->storage->ap_slotmem_mem(s->slotmem, jgroupsid->id, (void **) &ou);
     else {
-        rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_jgroupsid, &ou, s->p);
+        rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_jgroupsid, &ou, 0, s->p);
     }
     if (rv == APR_SUCCESS)
         return ou;
@@ -168,7 +168,7 @@ apr_status_t remove_jgroupsid(mem_t *s, jgroupsidinfo_t *jgroupsid)
         s->storage->ap_slotmem_free(s->slotmem, jgroupsid->id, jgroupsid);
     else {
         /* XXX: for the moment January 2007 ap_slotmem_free only uses ident to remove */
-        rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_jgroupsid, &ou, s->p);
+        rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_jgroupsid, &ou, 0, s->p);
         if (rv == APR_SUCCESS)
             rv = s->storage->ap_slotmem_free(s->slotmem, ou->id, jgroupsid);
     }

--- a/native/mod_manager/mod_manager.c
+++ b/native/mod_manager/mod_manager.c
@@ -141,8 +141,8 @@ typedef struct mod_manager_config
     /* max number of jgroupsid supported */
     int maxjgroupsid;
 
-    /* last time the node update logic was called */
-    apr_time_t last_updated;
+    /* version, the version is increased each time the node update logic is called */
+    unsigned int tableversion;
 
     /* Should be the slotmem persisted (1) or not (0) */
     int persistent;
@@ -204,42 +204,33 @@ static apr_status_t loc_find_node(nodeinfo_t **node, const char *route)
  * call to worker_nodes_are_updated().
  * return codes:
  *   0 : No update of the nodes since last time.
- *   x : Last time we changed something in the process.
+ *   x: The version has changed the local table need to be updated.
  */
-static apr_time_t loc_worker_nodes_need_update(void *data, apr_pool_t *pool)
+static unsigned int loc_worker_nodes_need_update(void *data, apr_pool_t *pool)
 {
-    int size, i;
-    int *id;
+    int size;
     server_rec *s = (server_rec *) data;
-    apr_time_t last = 0;
+    unsigned int last = 0;
     mod_manager_config *mconf = ap_get_module_config(s->module_config, &manager_module);
 
     size = loc_get_max_size_node();
     if (size == 0)
         return 0; /* broken */
-    id = apr_palloc(pool, sizeof(int) * size);
-    size = get_ids_used_node(nodestatsmem, id);
-    for (i=0; i<size; i++) {
-        nodeinfo_t *ou;
-        if (get_node(nodestatsmem, &ou, id[i]) != APR_SUCCESS)
-            continue;
-        if (ou->updatetime > last)
-            last = ou->updatetime;
-    }
-    if (last >= mconf->last_updated) {
-        if (mconf->last_updated == 0)
-            return(1); /* First time */
-        return(mconf->last_updated);
-    }
 
+    last = get_version_node(nodestatsmem);
+
+    if (last != mconf->tableversion)
+        return last;
+    if (mconf->tableversion == 0)
+        return 1; /* make sure it is updated */
     return (0);
 }
-/* Store the last update time in the proccess config */
-static int loc_worker_nodes_are_updated(void *data)
+/* Store the last version update in the proccess config */
+static int loc_worker_nodes_are_updated(void *data, unsigned int last)
 {
     server_rec *s = (server_rec *) data;
     mod_manager_config *mconf = ap_get_module_config(s->module_config, &manager_module);
-    mconf->last_updated = apr_time_now();
+    mconf->tableversion = last;
     return (0);
 }
 static int loc_get_max_size_context()
@@ -2689,7 +2680,7 @@ static void  manager_child_init(apr_pool_t *p, server_rec *s)
         return;
     }
 
-    mconf->last_updated = 0;
+    mconf->tableversion = 0;
 
     if (mconf->basefilename) {
         node = apr_pstrcat(p, mconf->basefilename, "/manager.node", NULL);
@@ -3049,7 +3040,7 @@ static void *create_manager_config(apr_pool_t *p)
     mconf->maxhost = DEFMAXHOST;
     mconf->maxsessionid = DEFMAXSESSIONID;
     mconf->maxjgroupsid = DEFMAXJGROUPSID;
-    mconf->last_updated = 0;
+    mconf->tableversion = 0;
     mconf->persistent = 0;
     mconf->nonce = -1;
     mconf->balancername = NULL;
@@ -3074,7 +3065,7 @@ static void *merge_manager_server_config(apr_pool_t *p, void *server1_conf,
     mconf->basefilename = NULL;
     mconf->maxcontext = DEFMAXCONTEXT;
     mconf->maxnode = DEFMAXNODE;
-    mconf->last_updated = 0;
+    mconf->tableversion = 0;
     mconf->persistent = 0;
     mconf->nonce = -1;
     mconf->balancername = NULL;

--- a/native/mod_manager/node.c
+++ b/native/mod_manager/node.c
@@ -121,7 +121,7 @@ apr_status_t insert_update_node(mem_t *s, nodeinfo_t *node, int *id)
 
     node->mess.id = 0;
     s->storage->ap_slotmem_lock(s->slotmem);
-    rv = s->storage->ap_slotmem_do(s->slotmem, insert_update, &node, s->p);
+    rv = s->storage->ap_slotmem_do(s->slotmem, insert_update, &node, 1, s->p);
     if (node->mess.id != 0 && rv == APR_SUCCESS) {
         s->storage->ap_slotmem_unlock(s->slotmem);
         *id = node->mess.id;
@@ -173,7 +173,7 @@ nodeinfo_t * read_node(mem_t *s, nodeinfo_t *node)
     if (node->mess.id)
         rv = s->storage->ap_slotmem_mem(s->slotmem, node->mess.id, (void **) &ou);
     else {
-        rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_node, &ou, s->p);
+        rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_node, &ou, 0, s->p);
     }
     if (rv == APR_SUCCESS)
         return ou;
@@ -205,7 +205,7 @@ apr_status_t remove_node(mem_t *s, nodeinfo_t *node)
         rv = s->storage->ap_slotmem_free(s->slotmem, node->mess.id, node);
     else {
         /* XXX: for the moment January 2007 ap_slotmem_free only uses ident to remove */
-        rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_node, &ou, s->p);
+        rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_node, &ou, 0, s->p);
         if (rv == APR_SUCCESS)
             rv = s->storage->ap_slotmem_free(s->slotmem, ou->mess.id, node);
     }
@@ -226,7 +226,7 @@ apr_status_t find_node(mem_t *s, nodeinfo_t **node, const char *route)
 
     strcpy(ou.mess.JVMRoute, route);
     *node = &ou;
-    rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_node, node, s->p);
+    rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_node, node, 0, s->p);
     return rv;
 }
 
@@ -252,6 +252,19 @@ int get_max_size_node(mem_t *s)
         return 0;
     else
         return (s->storage->ap_slotmem_get_max_size(s->slotmem));
+}
+
+/*
+ * read the version of the table.
+ * @param pointer to the shared table.
+ * @return the version of the table
+ */
+unsigned int get_version_node(mem_t *s)
+{
+    if (s->storage == NULL)
+        return 0;
+    else
+        return (s->storage->ap_slotmem_get_version(s->slotmem));
 }
 
 /**

--- a/native/mod_manager/sessionid.c
+++ b/native/mod_manager/sessionid.c
@@ -96,7 +96,7 @@ apr_status_t insert_update_sessionid(mem_t *s, sessionidinfo_t *sessionid)
 
     sessionid->id = 0;
     s->storage->ap_slotmem_lock(s->slotmem);
-    rv = s->storage->ap_slotmem_do(s->slotmem, insert_update, &sessionid, s->p);
+    rv = s->storage->ap_slotmem_do(s->slotmem, insert_update, &sessionid, 1, s->p);
     if (sessionid->id != 0 && rv == APR_SUCCESS) {
         s->storage->ap_slotmem_unlock(s->slotmem);
         return APR_SUCCESS; /* updated */
@@ -140,7 +140,7 @@ sessionidinfo_t * read_sessionid(mem_t *s, sessionidinfo_t *sessionid)
     if (sessionid->id)
         rv = s->storage->ap_slotmem_mem(s->slotmem, sessionid->id, (void **) &ou);
     else {
-        rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_sessionid, &ou, s->p);
+        rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_sessionid, &ou, 0, s->p);
     }
     if (rv == APR_SUCCESS)
         return ou;
@@ -172,7 +172,7 @@ apr_status_t remove_sessionid(mem_t *s, sessionidinfo_t *sessionid)
         s->storage->ap_slotmem_free(s->slotmem, sessionid->id, sessionid);
     else {
         /* XXX: for the moment January 2007 ap_slotmem_free only uses ident to remove */
-        rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_sessionid, &ou, s->p);
+        rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_sessionid, &ou, 0, s->p);
         if (rv == APR_SUCCESS)
             rv = s->storage->ap_slotmem_free(s->slotmem, ou->id, sessionid);
     }

--- a/native/mod_slotmem/sharedmem_util.c
+++ b/native/mod_slotmem/sharedmem_util.c
@@ -60,12 +60,14 @@
 struct sharedslotdesc {
     apr_size_t item_size;
     int item_num;
+    unsigned int version; /* integer updated each time we make a change through the API */
 };
 
 struct ap_slotmem {
     char *name;
     apr_shm_t *shm;
     int *ident; /* integer table to process a fast alloc/free */
+    unsigned int *version; /* address of version */
     void *base;
     apr_size_t size;
     int num;
@@ -198,7 +200,7 @@ apr_status_t cleanup_slotmem(void *param)
     return APR_SUCCESS;
 }
 
-static apr_status_t ap_slotmem_do(ap_slotmem_t *mem, mc_slotmem_callback_fn_t *func, void *data, apr_pool_t *pool)
+static apr_status_t ap_slotmem_do(ap_slotmem_t *mem, mc_slotmem_callback_fn_t *func, void *data, int new_version, apr_pool_t *pool)
 {
     int i, j, isfree, *ident;
     char *ptr;
@@ -221,8 +223,11 @@ static apr_status_t ap_slotmem_do(ap_slotmem_t *mem, mc_slotmem_callback_fn_t *f
         }
         if (!isfree) {
             rv = func((void *)ptr, data, i, pool);
-            if (rv == APR_SUCCESS)
+            if (rv == APR_SUCCESS) {
+                if (new_version)
+                   (*mem->version)++;
                 return(rv);
+            }
         }
         ptr = ptr + mem->size;
     }
@@ -250,7 +255,7 @@ static apr_status_t ap_slotmem_unlock(ap_slotmem_t *s)
 static apr_status_t ap_slotmem_create(ap_slotmem_t **new, const char *name, apr_size_t item_size, int item_num, int persist, apr_pool_t *pool)
 {
     char *ptr;
-    struct sharedslotdesc desc;
+    struct sharedslotdesc desc, *new_desc;
     ap_slotmem_t *res;
     ap_slotmem_t *next = globallistmem;
     apr_status_t rv;
@@ -325,6 +330,7 @@ static apr_status_t ap_slotmem_create(ap_slotmem_t **new, const char *name, apr_
             ap_slotmem_unlock(res);
             return APR_EINVAL;
         }
+        new_desc = (struct sharedslotdesc *) ptr;
         ptr = ptr +  dsize;
     }
     else  {
@@ -357,6 +363,7 @@ static apr_status_t ap_slotmem_create(ap_slotmem_t **new, const char *name, apr_
         ptr = apr_shm_baseaddr_get(res->shm);
         desc.item_size = item_size;
         desc.item_num = item_num;
+        new_desc = (struct sharedslotdesc *) ptr;
         memcpy(ptr, &desc, sizeof(desc));
         ptr = ptr +  dsize;
         /* write the idents table */
@@ -377,6 +384,7 @@ static apr_status_t ap_slotmem_create(ap_slotmem_t **new, const char *name, apr_
     res->base = ptr + tsize;
     res->size = item_size;
     res->num = item_num;
+    res->version = &(new_desc->version);
     res->globalpool = globalpool;
     res->next = NULL;
     if (globallistmem==NULL) {
@@ -458,6 +466,7 @@ static apr_status_t ap_slotmem_attach(ap_slotmem_t **new, const char *name, apr_
     res->base = ptr + tsize;
     res->size = desc.item_size;
     res->num = desc.item_num;
+    *res->version = 0;
     res->globalpool = globalpool;
     res->next = NULL;
     if (globallistmem==NULL) {
@@ -515,6 +524,7 @@ static apr_status_t ap_slotmem_alloc(ap_slotmem_t *score, int *item_id, void**me
         ident[ff] = 0;
         *item_id = ff;
         *mem = (char *) score->base + score->size * (ff - 1);
+        (*score->version)++;
         rv = APR_SUCCESS;
     }
     
@@ -531,12 +541,14 @@ static apr_status_t ap_slotmem_free(ap_slotmem_t *score, int item_id, void*mem)
         ident = score->ident;
         if (ident[item_id]) {
             ap_slotmem_unlock(score);
+            (*score->version)++;
             return APR_SUCCESS;
         }
         ff = ident[0];
         ident[0] = item_id;
         ident[item_id] = ff;
         ap_slotmem_unlock(score);
+        (*score->version)++;
         return APR_SUCCESS;
     }
 }
@@ -561,6 +573,12 @@ static int ap_slotmem_get_max_size(ap_slotmem_t *score)
         return 0;
     return score->num;
 }
+static unsigned int ap_slotmem_get_version(ap_slotmem_t *score)
+{
+    if (score == NULL)
+        return 0;
+    return *score->version;
+}
 static const slotmem_storage_method storage = {
     &ap_slotmem_do,
     &ap_slotmem_create,
@@ -571,7 +589,8 @@ static const slotmem_storage_method storage = {
     &ap_slotmem_get_used,
     &ap_slotmem_get_max_size,
     &ap_slotmem_lock,
-    &ap_slotmem_unlock
+    &ap_slotmem_unlock,
+    &ap_slotmem_get_version
 };
 
 /* make the storage usuable from outside


### PR DESCRIPTION
It fixesMODCLUSTER-372
Number of registered contexts negatively affects mod_cluster performances
Note that it is probably enough for MODCLUSTER-350 because in fact most of the time is spent in the shared memory access.
