### PR TITLE
1.2.x bz1080047 vol3

### DIFF
--- a/native/mod_manager/mod_manager.c
+++ b/native/mod_manager/mod_manager.c
@@ -2740,10 +2740,13 @@ static void  manager_child_init(apr_pool_t *p, server_rec *s)
         return;
     }
 
-    sessionidstatsmem = get_mem_sessionid(sessionid, &mconf->maxsessionid, p, storage);
-    if (sessionidstatsmem == NULL) {
-        ap_log_error(APLOG_MARK, APLOG_NOERRNO|APLOG_EMERG, 0, s, "get_mem_sessionid failed");
-        return;
+    if (mconf->maxsessionid) {
+        /*  Try to get sessionid stuff only if required */
+        sessionidstatsmem = get_mem_sessionid(sessionid, &mconf->maxsessionid, p, storage);
+        if (sessionidstatsmem == NULL) {
+            ap_log_error(APLOG_MARK, APLOG_NOERRNO|APLOG_EMERG, 0, s, "get_mem_sessionid failed");
+            return;
+        }
     }
 }
 


### PR DESCRIPTION
Solves the `[emerg] get_mem_sessionid failed` error.
