### PR TITLE
1.2.9.final fix bz987259

### DIFF
--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -2396,12 +2396,14 @@ static int proxy_node_isup(request_rec *r, int id, int load)
     else if (load == 0) {
 #if AP_MODULE_MAGIC_AT_LEAST(20051115,4)
         worker->s->status |= PROXY_WORKER_HOT_STANDBY;
+        worker->s->lbfactor = 0;
 #else
         /*
          * XXX: PROXY_WORKER_HOT_STANDBY Doesn't look supported
          * mark worker in error for the moment
          */
         worker->s->status |= PROXY_WORKER_IN_ERROR;
+        worker->s->lbfactor = -1;
 #endif
     }
     else {


### PR DESCRIPTION
Without this fix, mod_cluster manager console shows, e.g.:

```
Balancer: qacluster,LBGroup: ,Flushpackets: Off,Flushwait: 10000,Ping: 10000000,Smax: 1,Ttl: 60000000,Status: OK,Elected: 0,Read: 0,Transferred: 0,Connected: 0,Load: -1 
```

note Load: -1. Even if all workers but the hot-standby one are down, balancer won't target the -1 node.

This patch fixes it.
