### PR TITLE
Supply our default configuration for maven-release-plugin (autoVersionSu...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
+                <configuration>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                    <tagNameFormat>@{project.version}</tagNameFormat>
+                    <!-- After checking the created tag is correct, manually push the changes upstream with the release! -->
+                    <pushChanges>false</pushChanges>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
...bmodules, tagNameFormat, pushChanges)

So `autoVersionSubmodules` and `tagNameFormat` probably don't need discussion as the defaults are odd, but how do you guys feel about `pushChanges`?

http://maven.apache.org/maven-release/maven-release-plugin/prepare-mojo.html#pushChanges

Since we moved to git, we will now be able to verify the changes locally and only then push + release. 
WDYT?
