### PR TITLE
Add logic to lock the nodes tables

### DIFF
--- a/native/include/node.h
+++ b/native/include/node.h
@@ -144,6 +144,18 @@ apr_status_t remove_node(mem_t *s, nodeinfo_t *node);
 apr_status_t find_node(mem_t *s, nodeinfo_t **node, const char *route);
 
 /*
+ *  * lock the nodes table
+ *   * @param pointer to the shared table.
+ *    */
+void lock_nodes(mem_t *s);
+
+/*
+ *  * unlock the nodes table
+ *   * @param pointer to the shared table.
+ *    */
+void unlock_nodes(mem_t *s);
+
+/*
  * get the ids for the used (not free) nodes in the table
  * @param pointer to the shared table.
  * @param ids array of int to store the used id (must be big enough).
@@ -225,5 +237,16 @@ apr_status_t (*find_node)(nodeinfo_t **node, const char *route);
  * Remove the virtual hosts and contexts corresponding the node.
  */
 void (*remove_host_context)(int node, apr_pool_t *pool);
+
+/*
+ * lock the nodes table
+ */
+void (*lock_nodes)();
+
+/*
+ * unlock the nodes table
+ */
+void (*unlock_nodes)();
+
 };
 #endif /*NODE_H*/

--- a/native/mod_manager/mod_manager.c
+++ b/native/mod_manager/mod_manager.c
@@ -235,6 +235,14 @@ static int loc_worker_nodes_are_updated(void *data, unsigned int last)
     mconf->tableversion = last;
     return (0);
 }
+static void loc_lock_nodes()
+{
+    lock_nodes(nodestatsmem);
+}
+static void loc_unlock_nodes()
+{
+    unlock_nodes(nodestatsmem);
+}
 static int loc_get_max_size_context()
 {
     if (contextstatsmem)
@@ -292,6 +300,8 @@ static const struct node_storage_method node_storage =
     loc_remove_node,
     loc_find_node,
     loc_remove_host_context,
+    loc_lock_nodes,
+    loc_unlock_nodes
 };
 
 /*

--- a/native/mod_manager/node.c
+++ b/native/mod_manager/node.c
@@ -229,6 +229,25 @@ apr_status_t find_node(mem_t *s, nodeinfo_t **node, const char *route)
 }
 
 /*
+ *  * lock the nodes table
+ *   * @param pointer to the shared table.
+ *    */
+void lock_nodes(mem_t *s)
+{
+    s->storage->ap_slotmem_lock(s->slotmem);
+}
+
+/*
+ *  * unlock the nodes table
+ *   * @param pointer to the shared table.
+ *    */
+void unlock_nodes(mem_t *s)
+{
+    s->storage->ap_slotmem_unlock(s->slotmem);
+}
+
+
+/*
  * get the ids for the used (not free) nodes in the table
  * @param pointer to the shared table.
  * @param ids array of int to store the used id (must be big enough).


### PR DESCRIPTION
when using httpd-2.4.x the node tables gets corrupted (basically more information from the
workers are in the shared memory so the optimistic logic doesn't work.
The lock will be used in mod_proxy_cluster.c
