### PR TITLE
[MODCLUSTER-427] mod_cluster can break stickiness for the first request on new child processes

### DIFF
--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -2657,6 +2657,25 @@ static void  proxy_cluster_child_init(apr_pool_t *p, server_rec *s)
                     "proxy_cluster_child_init: apr_thread_cond_create failed");
     }
 
+    server_rec *s2 = main_server;
+    void *sconf = s2->module_config;
+    proxy_server_conf *conf = (proxy_server_conf *)
+        ap_get_module_config(sconf, &proxy_module);
+    if (conf) {
+        apr_pool_t *pool;
+        apr_pool_create(&pool, conf->pool);
+        while (s2) {
+            sconf = s2->module_config;
+            conf = (proxy_server_conf *)
+                ap_get_module_config(sconf, &proxy_module);
+
+            update_workers_node(conf, pool, s2, 0);
+
+            s2 = s2->next;
+        }
+        apr_pool_destroy(pool);
+    }
+
     rv = apr_thread_create(&watchdog_thread, NULL, proxy_cluster_watchdog_func, s, p);
     if (rv != APR_SUCCESS) {
         ap_log_error(APLOG_MARK, APLOG_ERR|APLOG_NOERRNO, 0, s,


### PR DESCRIPTION
https://issues.jboss.org/browse/MODCLUSTER-427
