### PR TITLE
Update encoding to java.lang canonical name (ISO8859_1)

### DIFF
--- a/core/src/main/java/org/jboss/modcluster/advertise/impl/AdvertiseListenerImpl.java
+++ b/core/src/main/java/org/jboss/modcluster/advertise/impl/AdvertiseListenerImpl.java
@@ -55,7 +55,7 @@ import org.jboss.modcluster.mcmp.MCMPHandler;
  * @author Mladen Turk
  */
 public class AdvertiseListenerImpl implements AdvertiseListener {
-    public static final String DEFAULT_ENCODING = "8859_1";
+    public static final String DEFAULT_ENCODING = "ISO8859_1";
     public static final String RFC_822_FMT = "EEE, d MMM yyyy HH:mm:ss Z";
 
     static final Logger log = Logger.getLogger(AdvertiseListenerImpl.class);


### PR DESCRIPTION
as per http://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html

Maybe this would fix the problem?
