### PR TITLE
MODCLUSTER-435: Comparing balancer name is now case-insensitive

### DIFF
--- a/native/mod_manager/mod_manager.c
+++ b/native/mod_manager/mod_manager.c
@@ -452,6 +452,22 @@ static void mc_initialize_cleanup(apr_pool_t *p)
     apr_pool_cleanup_register(p, NULL, cleanup_manager, apr_pool_cleanup_null);
 }
 
+void normalize_balancer_name(char* balancer_name, server_rec *s)
+{
+    int upper_case_char_found = 0;
+    char* balancer_name_start = balancer_name;
+    for (;*balancer_name; ++balancer_name) {
+        if(!upper_case_char_found) {
+            upper_case_char_found = apr_isupper(*balancer_name);
+        }
+        *balancer_name = apr_tolower(*balancer_name);
+    }
+    balancer_name = balancer_name_start;
+    if(upper_case_char_found) {
+        ap_log_error(APLOG_MARK, APLOG_NOERRNO|APLOG_WARNING, 0, s, "Balancer name contained an upper case character. We will use %s instead.", balancer_name);
+    }
+}
+
 /*
  * call after parser the configuration.
  * create the shared memory.
@@ -759,6 +775,7 @@ static char * process_config(request_rec *r, char **ptr, int *errtype)
     /* Fill default nodes values */
     memset(&nodeinfo.mess, '\0', sizeof(nodeinfo.mess));
     if (mconf->balancername != NULL) {
+        normalize_balancer_name(mconf->balancername, r->server);
         strcpy(nodeinfo.mess.balancer, mconf->balancername);
     } else {
         strcpy(nodeinfo.mess.balancer, "mycluster");
@@ -781,6 +798,7 @@ static char * process_config(request_rec *r, char **ptr, int *errtype)
     /* Fill default balancer values */
     memset(&balancerinfo, '\0', sizeof(balancerinfo));
     if (mconf->balancername != NULL) {
+        normalize_balancer_name(mconf->balancername, r->server);
         strcpy(balancerinfo.balancer, mconf->balancername);
     } else {
         strcpy(balancerinfo.balancer, "mycluster");
@@ -2819,6 +2837,7 @@ static const char *cmd_manager_balancername(cmd_parms *cmd, void *mconfig, const
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     mconf->balancername = apr_pstrdup(cmd->pool, word);
+    normalize_balancer_name(mconf->balancername, cmd->server);
     return NULL;
 }
 static const char*cmd_manager_pers(cmd_parms *cmd, void *dummy, const char *arg)

--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -2092,9 +2092,9 @@ static int isbalancer_ours(proxy_balancer *balancer, proxy_balancer_table *balan
     int i;
     for (i = 0; i < balancer_table->sizebalancer; i++) {
 #if AP_MODULE_MAGIC_AT_LEAST(20101223,1)
-        if (strcmp(balancer_table->balancer_info[i].balancer, &balancer->s->name[11]))
+        if (strcasecmp(balancer_table->balancer_info[i].balancer, &balancer->s->name[11]))
 #else
-        if (strcmp(balancer_table->balancer_info[i].balancer, &balancer->name[11]))
+        if (strcasecmp(balancer_table->balancer_info[i].balancer, &balancer->name[11]))
 #endif
             continue;
         else
@@ -2725,7 +2725,7 @@ static apr_status_t find_nodedomain(request_rec *r, char **domain, char *route, 
                  "find_nodedomain: finding node for %s: %s", route, balancer);
 #endif
     if (node_storage->find_node(&ou, route) == APR_SUCCESS) {
-        if (!strcmp(balancer, ou->mess.balancer)) {
+        if (!strcasecmp(balancer, ou->mess.balancer)) {
             if (ou->mess.Domain[0] != '\0') {
                 *domain = ou->mess.Domain;
             }


### PR DESCRIPTION
I have a test for this issue, addressing [BZ 1044879](https://bugzilla.redhat.com/show_bug.cgi?id=1044879)/[MODCLUSTER-435](https://issues.jboss.org/browse/MODCLUSTER-435). The test passes with this fix and related test cases on session stickiness and multiple balancer configurations didn't reveal any regression.
