### PR TITLE
[MODCLUSTER-443] recognize ; as a context delimiter

### DIFF
--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -1897,8 +1897,13 @@ static node_context *find_node_context_host(request_rec *r, proxy_balancer *bala
     uri = ap_strchr_c(luri, '?');
     if (uri)
        uri = apr_pstrndup(r->pool, luri, uri - luri);
-    else
-       uri = luri;
+    else {
+       uri = ap_strchr_c(luri, ';');
+       if (uri)
+          uri = apr_pstrndup(r->pool, luri, uri - luri);
+       else
+          uri = luri;
+    }
 
     /* read the contexts */
     if (sizecontext == 0)


### PR DESCRIPTION
https://issues.jboss.org/browse/MODCLUSTER-443
