### PR TITLE
MODCLUSTER-432 Multicast discovery does not work on Mac OS X, fails with "Can't assign requested address"

### DIFF
--- a/core/src/main/java/org/jboss/modcluster/advertise/AdvertiseListenerFactory.java
+++ b/core/src/main/java/org/jboss/modcluster/advertise/AdvertiseListenerFactory.java
@@ -28,8 +28,7 @@ import org.jboss.modcluster.mcmp.MCMPHandler;
 
 /**
  * @author Paul Ferraro
- * 
  */
 public interface AdvertiseListenerFactory {
-    public AdvertiseListener createListener(MCMPHandler handler, AdvertiseConfiguration config) throws IOException;
+    AdvertiseListener createListener(MCMPHandler handler, AdvertiseConfiguration config) throws IOException;
 }

--- a/core/src/main/java/org/jboss/modcluster/advertise/impl/MulticastSocketFactoryImpl.java
+++ b/core/src/main/java/org/jboss/modcluster/advertise/impl/MulticastSocketFactoryImpl.java
@@ -34,19 +34,20 @@ import org.jboss.modcluster.ModClusterLogger;
 import org.jboss.modcluster.advertise.MulticastSocketFactory;
 
 /**
- * On Linux, we attempt to avoid cross-talk problem by binding the MulticastSocket to the multicast address, if possible. See
- * {@linkplain https://jira.jboss.org/jira/browse/JGRP-777}
+ * On Linux, Solaris and HP-UX, we attempt to avoid cross-talk problem by binding the {@link MulticastSocket} to the
+ * multicast address, if possible. See <a href="https://jira.jboss.org/jira/browse/JGRP-777">JGRP-777</a>.
  * 
  * @author Paul Ferraro
  */
 public class MulticastSocketFactoryImpl implements MulticastSocketFactory {
     final Logger log = Logger.getLogger(this.getClass());
 
-    private final boolean linuxlike;
+    private final boolean canBindMulticastSocket;
 
     public MulticastSocketFactoryImpl() {
         String value = this.getSystemProperty("os.name");
-        this.linuxlike = (value != null) && (value.toLowerCase().startsWith("linux") || value.toLowerCase().startsWith("mac") || value.toLowerCase().startsWith("hp"));
+        this.canBindMulticastSocket = (value != null) && (value.toLowerCase().startsWith("linux") ||
+                value.toLowerCase().startsWith("sun") || value.toLowerCase().startsWith("hp"));
     }
 
     private String getSystemProperty(final String key) {
@@ -65,13 +66,9 @@ public class MulticastSocketFactoryImpl implements MulticastSocketFactory {
         return AccessController.doPrivileged(action);
     }
 
-    /**
-     * @{inheritDoc
-     * @see org.jboss.modcluster.advertise.MulticastSocketFactory#createMulticastSocket(java.net.InetAddress, int)
-     */
     @Override
     public MulticastSocket createMulticastSocket(InetAddress address, int port) throws IOException {
-        if ((address == null) || !this.linuxlike) return new MulticastSocket(port);
+        if ((address == null) || !this.canBindMulticastSocket) return new MulticastSocket(port);
 
         if (!address.isMulticastAddress()) {
             ModClusterLogger.LOGGER.createMulticastSocketWithUnicastAddress(address);

--- a/core/src/test/java/org/jboss/modcluster/advertise/AdvertiseListenerImplTestCase.java
+++ b/core/src/test/java/org/jboss/modcluster/advertise/AdvertiseListenerImplTestCase.java
@@ -46,7 +46,6 @@ import org.jboss.modcluster.config.AdvertiseConfiguration;
 import org.jboss.modcluster.mcmp.MCMPHandler;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -100,7 +99,6 @@ public class AdvertiseListenerImplTestCase {
     }
 
     @Test
-    @Ignore("MODCLUSTER-432")
     public void testBasicOperation() throws IOException, NoSuchAlgorithmException {
         ArgumentCaptor<InetAddress> capturedAddress = ArgumentCaptor.forClass(InetAddress.class);
 

--- a/core/src/test/java/org/jboss/modcluster/advertise/MulticastSocketFactoryImplTestCase.java
+++ b/core/src/test/java/org/jboss/modcluster/advertise/MulticastSocketFactoryImplTestCase.java
@@ -31,7 +31,6 @@ import java.util.Arrays;
 
 import org.jboss.modcluster.advertise.impl.MulticastSocketFactoryImpl;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -51,7 +50,6 @@ public class MulticastSocketFactoryImplTestCase {
     private static final int PORT = 23364;
 
     @Test
-    @Ignore("MODCLUSTER-432")
     public void testMulticastSocketNoCrossTalk() throws IOException {
         InetAddress address = InetAddress.getByName(GROUP1);
 


### PR DESCRIPTION
Trying multiple things to get this working, none helped. I feel like I am reinveting the wheel -- let's do what JGroups is doing. Looking through numerous Jiras on this, since cca. 2008 Bela has been saying that this doesn't work on OS X so I am sceptical if this has ever really worked...

Also includes:
Mirror JGroups behavior
Reenable tests
Include support for Solaris
Rename  the variable to represent better what the property is (was called linuxlike)
Fix redundant and incorrect javadoc

Jira
https://issues.jboss.org/browse/MODCLUSTER-432