### PR TITLE
MODCLUSTER-461 If Session ID key stored in URL contains sticky session cookie name it it used for routing

### DIFF
--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -1615,25 +1615,28 @@ static void remove_timeout_domain(apr_pool_t *pool, server_rec *server)
     } 
 }
 
-/* Retrieve the parameter with the given name
+/**
+ * Retrieve the parameter with the given name
  * Something like 'JSESSIONID=12345...N'
- * XXX: Should use the mod_proxy_balancer ones.
+ *
+ * TODO: Should use the mod_proxy_balancer one
  */
 static char *get_path_param(apr_pool_t *pool, char *url,
                             const char *name)
 {
     char *path = NULL;
+    char *pathdelims = ";?&";
 
     for (path = strstr(url, name); path; path = strstr(path + 1, name)) {
         path += strlen(name);
         if (*path == '=') {
             /*
-             * Session path was found, get it's value
+             * Session path was found, get its value
              */
             ++path;
-            if (strlen(path)) {
+            if (*path) {
                 char *q;
-                path = apr_strtok(apr_pstrdup(pool, path), "?&", &q);
+                path = apr_strtok(apr_pstrdup(pool, path), pathdelims, &q);
                 return path;
             }
         }

--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -1628,16 +1628,20 @@ static char *get_path_param(apr_pool_t *pool, char *url,
     char *pathdelims = ";?&";
 
     for (path = strstr(url, name); path; path = strstr(path + 1, name)) {
-        path += strlen(name);
-        if (*path == '=') {
-            /*
-             * Session path was found, get its value
-             */
-            ++path;
-            if (*path) {
-                char *q;
-                path = apr_strtok(apr_pstrdup(pool, path), pathdelims, &q);
-                return path;
+
+        /* Must be following a ';' and followed by '=' to be the correct session id name */
+        if (*(path - 1) == ';') {
+            path += strlen(name);
+            if (*path == '=') {
+                /*
+                 * Session path was found, get its value
+                 */
+                ++path;
+                if (*path) {
+                    char *q;
+                    path = apr_strtok(apr_pstrdup(pool, path), pathdelims, &q);
+                    return path;
+                }
             }
         }
     }

--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -1716,9 +1716,9 @@ static char *cluster_get_sessionid(request_rec *r, const char *stickyval, char *
          sticky_path = path;
     }
     *sticky_used = sticky_path;
-    route = get_path_param(r->pool, uri , sticky_path);
+    route = get_cookie_param(r, sticky, 1);
     if (!route) {
-        route = get_cookie_param(r, sticky, 1);
+        route = get_path_param(r->pool, uri, sticky_path);
         *sticky_used = sticky;
     }
     return route;


### PR DESCRIPTION
Addresses the following:

https://issues.jboss.org/browse/MODCLUSTER-461
https://issues.jboss.org/browse/MODCLUSTER-462
https://issues.jboss.org/browse/MODCLUSTER-285