### PR TITLE
Revert "MODCLUSTER-432 Multicast discovery does not work on Mac OS X,…

### DIFF
--- a/core/src/main/java/org/jboss/modcluster/advertise/impl/MulticastSocketFactoryImpl.java
+++ b/core/src/main/java/org/jboss/modcluster/advertise/impl/MulticastSocketFactoryImpl.java
@@ -34,20 +34,19 @@ import org.jboss.modcluster.ModClusterLogger;
 import org.jboss.modcluster.advertise.MulticastSocketFactory;
 
 /**
- * On Linux, Solaris and HP-UX, we attempt to avoid cross-talk problem by binding the {@link MulticastSocket} to the
- * multicast address, if possible. See <a href="https://jira.jboss.org/jira/browse/JGRP-777">JGRP-777</a>.
+ * On Linux, we attempt to avoid cross-talk problem by binding the MulticastSocket to the multicast address, if possible. See
+ * {@linkplain https://jira.jboss.org/jira/browse/JGRP-777}
  * 
  * @author Paul Ferraro
  */
 public class MulticastSocketFactoryImpl implements MulticastSocketFactory {
     final Logger log = Logger.getLogger(this.getClass());
 
-    private final boolean canBindMulticastSocket;
+    private final boolean linuxlike;
 
     public MulticastSocketFactoryImpl() {
         String value = this.getSystemProperty("os.name");
-        this.canBindMulticastSocket = (value != null) && (value.toLowerCase().startsWith("linux") ||
-                value.toLowerCase().startsWith("sun") || value.toLowerCase().startsWith("hp"));
+        this.linuxlike = (value != null) && (value.toLowerCase().startsWith("linux") || value.toLowerCase().startsWith("mac") || value.toLowerCase().startsWith("hp"));
     }
 
     private String getSystemProperty(final String key) {
@@ -66,9 +65,13 @@ public class MulticastSocketFactoryImpl implements MulticastSocketFactory {
         return AccessController.doPrivileged(action);
     }
 
+    /**
+     * @{inheritDoc
+     * @see org.jboss.modcluster.advertise.MulticastSocketFactory#createMulticastSocket(java.net.InetAddress, int)
+     */
     @Override
     public MulticastSocket createMulticastSocket(InetAddress address, int port) throws IOException {
-        if ((address == null) || !this.canBindMulticastSocket) return new MulticastSocket(port);
+        if ((address == null) || !this.linuxlike) return new MulticastSocket(port);
 
         if (!address.isMulticastAddress()) {
             ModClusterLogger.LOGGER.createMulticastSocketWithUnicastAddress(address);

--- a/core/src/test/java/org/jboss/modcluster/advertise/AdvertiseListenerImplTestCase.java
+++ b/core/src/test/java/org/jboss/modcluster/advertise/AdvertiseListenerImplTestCase.java
@@ -46,6 +46,7 @@ import org.jboss.modcluster.config.AdvertiseConfiguration;
 import org.jboss.modcluster.mcmp.MCMPHandler;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -99,6 +100,7 @@ public class AdvertiseListenerImplTestCase {
     }
 
     @Test
+    @Ignore("MODCLUSTER-432")
     public void testBasicOperation() throws IOException, NoSuchAlgorithmException {
         ArgumentCaptor<InetAddress> capturedAddress = ArgumentCaptor.forClass(InetAddress.class);
 

--- a/core/src/test/java/org/jboss/modcluster/advertise/MulticastSocketFactoryImplTestCase.java
+++ b/core/src/test/java/org/jboss/modcluster/advertise/MulticastSocketFactoryImplTestCase.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 
 import org.jboss.modcluster.advertise.impl.MulticastSocketFactoryImpl;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -50,6 +51,7 @@ public class MulticastSocketFactoryImplTestCase {
     private static final int PORT = 23364;
 
     @Test
+    @Ignore("MODCLUSTER-432")
     public void testMulticastSocketNoCrossTalk() throws IOException {
         InetAddress address = InetAddress.getByName(GROUP1);
 


### PR DESCRIPTION
… fails with "Can't assign requested address""

This reverts commit d74dc22db392eeadf3b7676e581ae5f749bd60b7.

Revert commits causing possible regressions and reopning the Jira.