### PR TITLE
MODCLUSTER-478 Session draining always takes maximum configured timeo…

### DIFF
--- a/core/src/main/java/org/jboss/modcluster/ModClusterLogger.java
+++ b/core/src/main/java/org/jboss/modcluster/ModClusterLogger.java
@@ -173,4 +173,8 @@ public interface ModClusterLogger {
     @LogMessage(level = WARN)
     @Message(id = 45, value = "%s is not supported on this system and will be disabled.")
     void notSupportedOnSystem(String classname);
+
+    @LogMessage(level = INFO)
+    @Message(id = 46, value = "Starting to drain %d active sessions from %s:%s in %d seconds.")
+    void startSessionDraining(int sessions, Host host, Context context, long timeout);
 }

--- a/core/src/main/java/org/jboss/modcluster/ModClusterService.java
+++ b/core/src/main/java/org/jboss/modcluster/ModClusterService.java
@@ -827,6 +827,9 @@ public class ModClusterService implements ModClusterServiceMBean, ContainerEvent
         if (remainingSessions == 0)
             return true;
 
+        // Notify the user that the server is draining sessions since it might appear stuck since messages while draining are on DEBUG
+        ModClusterLogger.LOGGER.startSessionDraining(remainingSessions, context.getHost(), context, TimeUnit.MILLISECONDS.toSeconds(end - start));
+
         boolean noTimeout = (start >= end);
 
         HttpSessionListener listener = new NotifyOnDestroySessionListener();
@@ -843,7 +846,9 @@ public class ModClusterService implements ModClusterServiceMBean, ContainerEvent
                 while ((remainingSessions > 0) && (noTimeout || (timeout > 0))) {
                     ModClusterLogger.LOGGER.drainSessions(remainingSessions, context.getHost(), context);
 
-                    listener.wait(noTimeout ? 0 : timeout);
+                    // Poll active sessions every second since since right after the notify, the session manager implementation
+                    // will still account for that last session.
+                    listener.wait(noTimeout ? 0 : Math.min(timeout, 1000));
 
                     current = System.currentTimeMillis();
                     timeout = end - current;
@@ -889,13 +894,13 @@ public class ModClusterService implements ModClusterServiceMBean, ContainerEvent
         return context;
     }
 
-    static interface Enablable {
+    interface Enablable {
         boolean isEnabled();
 
         void setEnabled(boolean enabled);
     }
 
-    static interface EnablableRequestListener extends Enablable, ServletRequestListener {
+    interface EnablableRequestListener extends Enablable, ServletRequestListener {
     }
 
     static class NotifyOnDestroyRequestListener implements EnablableRequestListener {


### PR DESCRIPTION
…ut since listener is always notified before session is removed

https://issues.jboss.org/browse/MODCLUSTER-478