### PR TITLE
MODCLUSTER-478 Session draining always takes maximum configured timeo…

### DIFF
--- a/core/src/main/java/org/jboss/modcluster/ModClusterLogger.java
+++ b/core/src/main/java/org/jboss/modcluster/ModClusterLogger.java
@@ -161,4 +161,8 @@ public interface ModClusterLogger {
     @LogMessage(level = WARN)
     @Message(id = 45, value = "%s is not supported on this system and will be disabled.")
     void notSupportedOnSystem(String classname);
+
+    @LogMessage(level = INFO)
+    @Message(id = 46, value = "Starting to drain %d active sessions from %s:%s in %d seconds.")
+    void startSessionDraining(int sessions, Host host, Context context, long timeout);
 }


### PR DESCRIPTION
…ut since listener is always notified before session is removed

https://issues.jboss.org/browse/MODCLUSTER-478