### PR TITLE
MODCLUSTER-497 ModClusterConfig#setAdvertiseInterface(java.lang.Strin…

### DIFF
--- a/core/src/main/java/org/jboss/modcluster/config/impl/ModClusterConfig.java
+++ b/core/src/main/java/org/jboss/modcluster/config/impl/ModClusterConfig.java
@@ -118,7 +118,7 @@ public class ModClusterConfig implements BalancerConfiguration, MCMPHandlerConfi
         this.advertiseInterface = advertiseInterface;
     }
 
-    @Deprecated
+    /* Used by Tomcat modeler and server.xml */
     public void setAdvertiseInterface(String advertiseInterface) {
         try {
             this.setAdvertiseInterface(InetAddress.getByName(advertiseInterface));


### PR DESCRIPTION
…g) should not have been deprecated as it's used by Tomcat modeller