### PR TITLE
MODCLUSTER-493 Add support for Tomcat 8.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ container
   tomcat6 (Tomcat 6.0 container implementation)
   tomcat7 (Tomcat 7.0 container implementation)
   tomcat8 (Tomcat 8.0 container implementation)
+  tomcat85 (Tomcat 8.5 container implementation)
   tomcat9 (experimental Tomcat 9.0 milestone release container implementation)
 core
 demo

--- a/container/catalina/pom.xml
+++ b/container/catalina/pom.xml
@@ -79,6 +79,7 @@
                 </dependency>
             </dependencies>
         </profile>
+        <!--
         <profile>
             <id>TC9</id>
             <activation>
@@ -107,6 +108,38 @@
                     <groupId>org.apache.tomcat</groupId>
                     <artifactId>tomcat-servlet-api</artifactId>
                     <version>${version.tomcat9}</version>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>TC85</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.tomcat</groupId>
+                    <artifactId>tomcat-catalina</artifactId>
+                    <version>${version.tomcat85}</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.tomcat</groupId>
+                    <artifactId>tomcat-coyote</artifactId>
+                    <version>${version.tomcat85}</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.tomcat</groupId>
+                    <artifactId>tomcat-util</artifactId>
+                    <version>${version.tomcat85}</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.tomcat</groupId>
+                    <artifactId>tomcat-servlet-api</artifactId>
+                    <version>${version.tomcat85}</version>
                     <scope>provided</scope>
                 </dependency>
             </dependencies>
@@ -143,6 +176,7 @@
                 </dependency>
             </dependencies>
         </profile>
+        -->
         <profile>
             <id>TC7</id>
             <activation>

--- a/container/pom.xml
+++ b/container/pom.xml
@@ -68,6 +68,16 @@
             </modules>
         </profile>
         <profile>
+            <id>TC85</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <modules>
+                <module>catalina</module>
+                <module>tomcat85</module>
+            </modules>
+        </profile>
+        <profile>
             <id>TC8</id>
             <activation>
                 <activeByDefault>false</activeByDefault>

--- a/container/tomcat85/pom.xml
+++ b/container/tomcat85/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2016, Red Hat Middleware LLC, and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jboss.mod_cluster</groupId>
+        <artifactId>mod_cluster-container</artifactId>
+        <version>2.0.0.Alpha1-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+    <artifactId>mod_cluster-container-tomcat85</artifactId>
+    <name>mod_cluster: Container - Tomcat 8.5</name>
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>mod_cluster-container-catalina</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>mod_cluster-container-catalina</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-catalina</artifactId>
+            <version>${version.tomcat85}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-coyote</artifactId>
+            <version>${version.tomcat85}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-util</artifactId>
+            <version>${version.tomcat85}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/container/tomcat85/src/main/java/org/jboss/modcluster/container/tomcat/TomcatConnector.java
+++ b/container/tomcat85/src/main/java/org/jboss/modcluster/container/tomcat/TomcatConnector.java
@@ -1,0 +1,81 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.modcluster.container.tomcat;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import org.apache.catalina.LifecycleState;
+import org.apache.catalina.connector.Connector;
+import org.apache.coyote.RequestGroupInfo;
+import org.apache.tomcat.util.net.AbstractEndpoint;
+import org.apache.tomcat.util.threads.ResizableExecutor;
+import org.jboss.modcluster.container.catalina.CatalinaConnector;
+
+/**
+ * @author Paul Ferraro
+ * @author Radoslav Husar
+ * @version Mar 2016
+ */
+public class TomcatConnector extends CatalinaConnector {
+
+    public TomcatConnector(Connector connector) {
+        super(connector);
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return LifecycleState.STARTED.equals(this.connector.getState());
+    }
+
+    @Override
+    public int getMaxThreads() {
+        Executor executor = this.connector.getProtocolHandler().getExecutor();
+        if (executor != null) {
+            if (executor instanceof ThreadPoolExecutor) {
+                return ((ThreadPoolExecutor) executor).getMaximumPoolSize();
+            } else if (executor instanceof ResizableExecutor) {
+                return ((ResizableExecutor) executor).getMaxThreads();
+            }
+        }
+        return 0;
+    }
+
+    @Override
+    public int getBusyThreads() {
+        Executor executor = this.connector.getProtocolHandler().getExecutor();
+        if (executor != null) {
+            if (executor instanceof ThreadPoolExecutor) {
+                return ((ThreadPoolExecutor) executor).getActiveCount();
+            } else if (executor instanceof ResizableExecutor) {
+                return ((ResizableExecutor) executor).getActiveCount();
+            }
+        }
+        return 0;
+    }
+
+    @Override
+    protected RequestGroupInfo getRequestGroupInfo(Object connectionHandler) {
+        AbstractEndpoint.Handler handler = (AbstractEndpoint.Handler) connectionHandler;
+        return (RequestGroupInfo) handler.getGlobal();
+    }
+}

--- a/container/tomcat85/src/main/java/org/jboss/modcluster/container/tomcat/TomcatConnectorFactory.java
+++ b/container/tomcat85/src/main/java/org/jboss/modcluster/container/tomcat/TomcatConnectorFactory.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.modcluster.container.tomcat;
+
+import org.jboss.modcluster.container.Connector;
+import org.jboss.modcluster.container.catalina.ConnectorFactory;
+
+/**
+ * @author Paul Ferraro
+ * @author Radoslav Husar
+ * @version Mar 2016
+ */
+public class TomcatConnectorFactory implements ConnectorFactory {
+    @Override
+    public Connector createConnector(org.apache.catalina.connector.Connector connector) {
+        return new TomcatConnector(connector);
+    }
+}

--- a/container/tomcat85/src/main/java/org/jboss/modcluster/container/tomcat/TomcatContext.java
+++ b/container/tomcat85/src/main/java/org/jboss/modcluster/container/tomcat/TomcatContext.java
@@ -1,0 +1,113 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.modcluster.container.tomcat;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequestEvent;
+import javax.servlet.ServletRequestListener;
+
+import org.apache.catalina.LifecycleState;
+import org.apache.catalina.Context;
+import org.apache.catalina.Valve;
+import org.apache.catalina.connector.Request;
+import org.apache.catalina.connector.Response;
+import org.apache.catalina.valves.ValveBase;
+import org.jboss.modcluster.container.Host;
+import org.jboss.modcluster.container.catalina.CatalinaContext;
+import org.jboss.modcluster.container.catalina.RequestListenerValveFactory;
+
+/**
+ * @author Paul Ferraro
+ * @author Radoslav Husar
+ * @version Mar 2016
+ */
+public class TomcatContext extends CatalinaContext {
+
+    public TomcatContext(Context context, Host host) {
+        super(context, host, new RequestListenerValveFactory() {
+            @Override
+            public Valve createValve(ServletRequestListener listener) {
+                return new RequestListenerValve(listener);
+            }
+        });
+    }
+
+    @Override
+    public boolean isStarted() {
+        return LifecycleState.STARTED.equals(this.context.getState());
+    }
+
+    @Override
+    public boolean isDistributable() {
+        return context.getDistributable();
+    }
+
+    private static class RequestListenerValve extends ValveBase {
+        private final ServletRequestListener listener;
+
+        RequestListenerValve(ServletRequestListener listener) {
+            this.listener = listener;
+        }
+
+
+        @Override
+        public void invoke(Request request, Response response) throws IOException, ServletException {
+            ServletRequestEvent requestEvent = new ServletRequestEvent(request.getContext().getServletContext(), request);
+
+            this.listener.requestInitialized(requestEvent);
+
+            Valve valve = this.getNext();
+
+            try {
+                valve.invoke(request, response);
+            } finally {
+                this.listener.requestDestroyed(requestEvent);
+            }
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see java.lang.Object#hashCode()
+         */
+        @Override
+        public int hashCode() {
+            return this.listener.hashCode();
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see java.lang.Object#equals(java.lang.Object)
+         */
+        @Override
+        public boolean equals(Object object) {
+            if ((object == null) || !(object instanceof RequestListenerValve)) return false;
+
+            RequestListenerValve valve = (RequestListenerValve) object;
+
+            return this.listener == valve.listener;
+        }
+    }
+}

--- a/container/tomcat85/src/main/java/org/jboss/modcluster/container/tomcat/TomcatContextFactory.java
+++ b/container/tomcat85/src/main/java/org/jboss/modcluster/container/tomcat/TomcatContextFactory.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.modcluster.container.tomcat;
+
+import org.jboss.modcluster.container.Context;
+import org.jboss.modcluster.container.Host;
+import org.jboss.modcluster.container.catalina.ContextFactory;
+
+/**
+ * @author Paul Ferraro
+ * @author Radoslav Husar
+ * @version May 2016
+ */
+public class TomcatContextFactory implements ContextFactory {
+    @Override
+    public Context createContext(org.apache.catalina.Context context, Host host) {
+        return new TomcatContext(context, host);
+    }
+}

--- a/container/tomcat85/src/main/java/org/jboss/modcluster/container/tomcat/TomcatEngine.java
+++ b/container/tomcat85/src/main/java/org/jboss/modcluster/container/tomcat/TomcatEngine.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.modcluster.container.tomcat;
+
+import org.apache.catalina.Engine;
+import org.apache.catalina.util.SessionConfig;
+import org.jboss.modcluster.container.Server;
+import org.jboss.modcluster.container.catalina.CatalinaEngine;
+import org.jboss.modcluster.container.catalina.CatalinaFactoryRegistry;
+
+/**
+ * Custom engine implementation for Tomcat 9.
+ *
+ * @author Paul Ferraro
+ * @author Radoslav Husar
+ * @version Mar 2016
+ */
+public class TomcatEngine extends CatalinaEngine {
+
+    public TomcatEngine(CatalinaFactoryRegistry registry, Engine engine, Server server) {
+        super(registry, engine, server);
+    }
+
+    // TODO MODCLUSTER-477 Broken design: cookie-name should be specified on the Context level instead of only on the Engine level
+    @Override
+    public String getSessionCookieName() {
+        return SessionConfig.getSessionCookieName(null);
+    }
+
+    // TODO MODCLUSTER-477 Broken design: cookie-name should be specified on the Context level instead of only on the Engine level
+    @Override
+    public String getSessionParameterName() {
+        return SessionConfig.getSessionUriParamName(null);
+    }
+}

--- a/container/tomcat85/src/main/java/org/jboss/modcluster/container/tomcat/TomcatEngineFactory.java
+++ b/container/tomcat85/src/main/java/org/jboss/modcluster/container/tomcat/TomcatEngineFactory.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.modcluster.container.tomcat;
+
+import org.jboss.modcluster.container.Engine;
+import org.jboss.modcluster.container.Server;
+import org.jboss.modcluster.container.catalina.CatalinaFactoryRegistry;
+import org.jboss.modcluster.container.catalina.EngineFactory;
+
+/**
+ * @author Paul Ferraro
+ * @author Radoslav Husar
+ * @version Mar 2016
+ */
+public class TomcatEngineFactory implements EngineFactory {
+
+    @Override
+    public Engine createEngine(CatalinaFactoryRegistry registry, org.apache.catalina.Engine engine, Server server) {
+        return new TomcatEngine(registry, engine, server);
+    }
+}

--- a/container/tomcat85/src/main/java/org/jboss/modcluster/container/tomcat/TomcatEventHandlerAdapter.java
+++ b/container/tomcat85/src/main/java/org/jboss/modcluster/container/tomcat/TomcatEventHandlerAdapter.java
@@ -1,0 +1,96 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.modcluster.container.tomcat;
+
+import org.apache.catalina.Container;
+import org.apache.catalina.Lifecycle;
+import org.apache.catalina.LifecycleEvent;
+import org.apache.catalina.Server;
+import org.apache.catalina.Service;
+import org.jboss.modcluster.container.ContainerEventHandler;
+import org.jboss.modcluster.container.catalina.CatalinaEventHandlerAdapter;
+import org.jboss.modcluster.container.catalina.CatalinaFactory;
+import org.jboss.modcluster.container.catalina.ServerProvider;
+
+/**
+ * @author Paul Ferraro
+ * @author Radoslav Husar
+ * @version Mar 2016
+ */
+public class TomcatEventHandlerAdapter extends CatalinaEventHandlerAdapter {
+
+    public TomcatEventHandlerAdapter(ContainerEventHandler eventHandler) {
+        super(eventHandler);
+    }
+
+    public TomcatEventHandlerAdapter(ContainerEventHandler eventHandler, ServerProvider serverProvider, CatalinaFactory factory) {
+        super(eventHandler, serverProvider, factory);
+    }
+
+    @Override
+    protected boolean isAfterInit(LifecycleEvent event) {
+        return event.getType().equals(Lifecycle.AFTER_INIT_EVENT);
+    }
+
+    @Override
+    protected boolean isBeforeDestroy(LifecycleEvent event) {
+        return event.getType().equals(Lifecycle.BEFORE_DESTROY_EVENT);
+    }
+
+    @Override
+    protected void addListeners(Server server) {
+        // Register ourself as a listener for child services
+        for (Service service : server.findServices()) {
+            Container engine = service.getContainer();
+            engine.addContainerListener(this);
+            engine.addLifecycleListener(this);
+
+            for (Container host : engine.findChildren()) {
+                host.addContainerListener(this);
+
+                for (Container context : host.findChildren()) {
+                    context.addLifecycleListener(this);
+                    context.addPropertyChangeListener(this);
+                }
+            }
+        }
+    }
+
+    @Override
+    protected void removeListeners(Server server) {
+        // Unregister ourself as a listener to child components
+        for (Service service : server.findServices()) {
+            Container engine = service.getContainer();
+            engine.removeContainerListener(this);
+            engine.removeLifecycleListener(this);
+
+            for (Container host : engine.findChildren()) {
+                host.removeContainerListener(this);
+
+                for (Container context : host.findChildren()) {
+                    context.removeLifecycleListener(this);
+                    context.removePropertyChangeListener(this);
+                }
+            }
+        }
+    }
+}

--- a/container/tomcat85/src/main/java/org/jboss/modcluster/container/tomcat/TomcatLifecycleListenerFactory.java
+++ b/container/tomcat85/src/main/java/org/jboss/modcluster/container/tomcat/TomcatLifecycleListenerFactory.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.modcluster.container.tomcat;
+
+import org.apache.catalina.LifecycleListener;
+import org.jboss.modcluster.container.ContainerEventHandler;
+import org.jboss.modcluster.container.catalina.LifecycleListenerFactory;
+
+/**
+ * @author Paul Ferraro
+ * @author Radoslav Husar
+ * @version Mar 2016
+ */
+public class TomcatLifecycleListenerFactory implements LifecycleListenerFactory {
+
+    @Override
+    public LifecycleListener createListener(ContainerEventHandler handler) {
+        return new TomcatEventHandlerAdapter(handler);
+    }
+}

--- a/container/tomcat85/src/main/java/org/jboss/modcluster/container/tomcat/TomcatServer.java
+++ b/container/tomcat85/src/main/java/org/jboss/modcluster/container/tomcat/TomcatServer.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.modcluster.container.tomcat;
+
+import org.apache.catalina.Service;
+import org.jboss.modcluster.container.Engine;
+import org.jboss.modcluster.container.catalina.CatalinaFactoryRegistry;
+import org.jboss.modcluster.container.catalina.CatalinaServer;
+
+import java.util.Arrays;
+import java.util.Iterator;
+
+/**
+ * Needs to recompile against Tomcat 9 Jar due to {@link Service#getContainer()} signature change.
+ *
+ * @author Paul Ferraro
+ * @author Radoslav Husar
+ * @version May 2016
+ */
+public class TomcatServer extends CatalinaServer {
+
+    public TomcatServer(CatalinaFactoryRegistry registry, org.apache.catalina.Server server) {
+        super(registry, server);
+    }
+
+    @Override
+    public Iterable<Engine> getEngines() {
+        final Iterator<Service> services = Arrays.asList(this.server.findServices()).iterator();
+
+        final Iterator<Engine> engines = new Iterator<Engine>() {
+            @Override
+            public boolean hasNext() {
+                return services.hasNext();
+            }
+
+            @Override
+            public Engine next() {
+                return TomcatServer.this.registry.getEngineFactory().createEngine(TomcatServer.this.registry, (org.apache.catalina.Engine) services.next().getContainer(), TomcatServer.this);
+            }
+
+            @Override
+            public void remove() {
+                services.remove();
+            }
+        };
+
+        return new Iterable<Engine>() {
+            @Override
+            public Iterator<Engine> iterator() {
+                return engines;
+            }
+        };
+    }
+}

--- a/container/tomcat85/src/main/java/org/jboss/modcluster/container/tomcat/TomcatServerFactory.java
+++ b/container/tomcat85/src/main/java/org/jboss/modcluster/container/tomcat/TomcatServerFactory.java
@@ -1,0 +1,17 @@
+package org.jboss.modcluster.container.tomcat;
+
+import org.jboss.modcluster.container.Server;
+import org.jboss.modcluster.container.catalina.CatalinaFactoryRegistry;
+import org.jboss.modcluster.container.catalina.ServerFactory;
+
+/**
+ * @author Paul Ferraro
+ * @author Radoslav Husar
+ * @version May 2016
+ */
+public class TomcatServerFactory implements ServerFactory {
+    @Override
+    public Server createServer(CatalinaFactoryRegistry registry, org.apache.catalina.Server server) {
+        return new TomcatServer(registry, server);
+    }
+}

--- a/container/tomcat85/src/main/resources/META-INF/services/org.jboss.modcluster.container.catalina.ConnectorFactory
+++ b/container/tomcat85/src/main/resources/META-INF/services/org.jboss.modcluster.container.catalina.ConnectorFactory
@@ -1,0 +1,22 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2016, Red Hat Middleware LLC, and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+org.jboss.modcluster.container.tomcat.TomcatConnectorFactory

--- a/container/tomcat85/src/main/resources/META-INF/services/org.jboss.modcluster.container.catalina.ContextFactory
+++ b/container/tomcat85/src/main/resources/META-INF/services/org.jboss.modcluster.container.catalina.ContextFactory
@@ -1,0 +1,22 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2016, Red Hat Middleware LLC, and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+org.jboss.modcluster.container.tomcat.TomcatContextFactory

--- a/container/tomcat85/src/main/resources/META-INF/services/org.jboss.modcluster.container.catalina.EngineFactory
+++ b/container/tomcat85/src/main/resources/META-INF/services/org.jboss.modcluster.container.catalina.EngineFactory
@@ -1,0 +1,22 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2016, Red Hat Middleware LLC, and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+org.jboss.modcluster.container.tomcat.TomcatEngineFactory

--- a/container/tomcat85/src/main/resources/META-INF/services/org.jboss.modcluster.container.catalina.LifecycleListenerFactory
+++ b/container/tomcat85/src/main/resources/META-INF/services/org.jboss.modcluster.container.catalina.LifecycleListenerFactory
@@ -1,0 +1,22 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2016, Red Hat Middleware LLC, and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+org.jboss.modcluster.container.tomcat.TomcatLifecycleListenerFactory

--- a/container/tomcat85/src/main/resources/META-INF/services/org.jboss.modcluster.container.catalina.ServerFactory
+++ b/container/tomcat85/src/main/resources/META-INF/services/org.jboss.modcluster.container.catalina.ServerFactory
@@ -1,0 +1,22 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2016, Red Hat Middleware LLC, and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+org.jboss.modcluster.container.tomcat.TomcatServerFactory

--- a/container/tomcat85/src/test/java/org/jboss/modcluster/container/tomcat/ConnectorTestCase.java
+++ b/container/tomcat85/src/test/java/org/jboss/modcluster/container/tomcat/ConnectorTestCase.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.modcluster.container.tomcat;
+
+import org.apache.tomcat.util.IntrospectionUtils;
+import org.jboss.modcluster.container.Connector;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Paul Ferraro
+ */
+public class ConnectorTestCase extends org.jboss.modcluster.container.catalina.ConnectorTestCase {
+
+    @Override
+    protected Connector createConnector(org.apache.catalina.connector.Connector connector) {
+        return new TomcatConnector(connector);
+    }
+
+    @Override
+    protected void setSecure(org.apache.catalina.connector.Connector connector, boolean secure) {
+        IntrospectionUtils.setProperty(connector.getProtocolHandler(), "secure", Boolean.toString(secure));
+    }
+
+    @Test
+    public void getMaxThreads() {
+        Assert.assertEquals(0, this.httpConnector.getMaxThreads());
+        Assert.assertEquals(0, this.httpsConnector.getMaxThreads());
+        Assert.assertEquals(0, this.ajpConnector.getMaxThreads());
+    }
+
+    @Test
+    public void getBusyThreads() {
+        Assert.assertEquals(0, this.httpConnector.getBusyThreads());
+        Assert.assertEquals(0, this.httpsConnector.getBusyThreads());
+        Assert.assertEquals(0, this.ajpConnector.getBusyThreads());
+    }
+
+}

--- a/container/tomcat85/src/test/java/org/jboss/modcluster/container/tomcat/ContextTestCase.java
+++ b/container/tomcat85/src/test/java/org/jboss/modcluster/container/tomcat/ContextTestCase.java
@@ -1,0 +1,104 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.modcluster.container.tomcat;
+
+import org.apache.catalina.LifecycleState;
+import org.apache.catalina.Pipeline;
+import org.apache.catalina.Valve;
+import org.jboss.modcluster.container.Context;
+import org.jboss.modcluster.container.Host;
+import org.mockito.ArgumentCaptor;
+
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequestListener;
+import java.io.IOException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Paul Ferraro
+ * @author Radoslav Husar
+ * @version May 2016
+ */
+public class ContextTestCase extends org.jboss.modcluster.container.catalina.ContextTestCase {
+
+    @Override
+    protected Context createContext(org.apache.catalina.Context context, Host host) {
+        return new TomcatContext(context, host);
+    }
+
+    @Override
+    public void isStarted() {
+        when(this.context.getState()).thenReturn(LifecycleState.STOPPED);
+
+        boolean result = this.catalinaContext.isStarted();
+
+        assertFalse(result);
+
+        when(this.context.getState()).thenReturn(LifecycleState.STARTED);
+
+        result = this.catalinaContext.isStarted();
+
+        assertTrue(result);
+    }
+
+    @Override
+    public void requestListener() throws IOException, ServletException {
+        // Test addRequestListener()
+        ServletRequestListener listener = mock(ServletRequestListener.class);
+        Pipeline pipeline = mock(Pipeline.class);
+        ArgumentCaptor<Valve> capturedValve = ArgumentCaptor.forClass(Valve.class);
+
+        when(this.context.getPipeline()).thenReturn(pipeline);
+
+        this.catalinaContext.addRequestListener(listener);
+
+        verify(pipeline).addValve(capturedValve.capture());
+
+        Valve valve = capturedValve.getValue();
+
+        // Test removeRequestListener()
+        when(this.context.getPipeline()).thenReturn(pipeline);
+        when(pipeline.getValves()).thenReturn(new Valve[] { valve });
+
+        this.catalinaContext.removeRequestListener(listener);
+
+        verify(pipeline).removeValve(same(valve));
+    }
+
+    @Override
+    public void isDistributable() {
+        org.apache.catalina.Context context = mock(org.apache.catalina.Context.class);
+        when(context.getDistributable()).thenReturn(true);
+
+        Context distributableContext = this.createContext(context, host);
+
+        boolean result = distributableContext.isDistributable();
+
+        assertTrue(result);
+    }
+}

--- a/container/tomcat85/src/test/java/org/jboss/modcluster/container/tomcat/EngineTestCase.java
+++ b/container/tomcat85/src/test/java/org/jboss/modcluster/container/tomcat/EngineTestCase.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.modcluster.container.tomcat;
+
+import org.jboss.modcluster.container.Engine;
+
+/**
+ * @author Paul Ferraro
+ */
+public class EngineTestCase extends org.jboss.modcluster.container.catalina.EngineTestCase {
+
+    @Override
+    protected Engine createEngine() {
+        return new TomcatEngine(this.registry, this.engine, this.server);
+    }
+}

--- a/container/tomcat85/src/test/java/org/jboss/modcluster/container/tomcat/HostTestCase.java
+++ b/container/tomcat85/src/test/java/org/jboss/modcluster/container/tomcat/HostTestCase.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.modcluster.container.tomcat;
+
+
+/**
+ * @author Paul Ferraro
+ */
+public class HostTestCase extends org.jboss.modcluster.container.catalina.HostTestCase {
+}

--- a/container/tomcat85/src/test/java/org/jboss/modcluster/container/tomcat/ServerTestCase.java
+++ b/container/tomcat85/src/test/java/org/jboss/modcluster/container/tomcat/ServerTestCase.java
@@ -1,0 +1,72 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.modcluster.container.tomcat;
+
+
+import org.apache.catalina.Service;
+import org.jboss.modcluster.container.Engine;
+import org.jboss.modcluster.container.Server;
+import org.jboss.modcluster.container.catalina.EngineFactory;
+
+import java.util.Iterator;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Needs to recompile against Tomcat 9 Jar due to {@link Service#getContainer()} signature change.
+ *
+ * @author Paul Ferraro
+ * @author Radoslav Husar
+ * @version May 2016
+ */
+public class ServerTestCase extends org.jboss.modcluster.container.catalina.ServerTestCase {
+
+    @Override
+    protected Server createServer(org.apache.catalina.Server server) {
+        return new TomcatServer(this.registry, server);
+    }
+
+    @Override
+    public void getEngines() {
+        Service service = mock(Service.class);
+        org.apache.catalina.Engine engine = mock(org.apache.catalina.Engine.class);
+        EngineFactory engineFactory = mock(EngineFactory.class);
+        Engine expected = mock(Engine.class);
+
+        when(this.server.findServices()).thenReturn(new Service[] { service });
+        when(service.getContainer()).thenReturn(engine);
+        when(this.registry.getEngineFactory()).thenReturn(engineFactory);
+        when(engineFactory.createEngine(same(this.registry), same(engine), same(this.catalinaServer))).thenReturn(expected);
+        Iterable<Engine> result = this.catalinaServer.getEngines();
+
+        Iterator<Engine> engines = result.iterator();
+
+        assertTrue(engines.hasNext());
+        assertSame(expected, engines.next());
+        assertFalse(engines.hasNext());
+    }
+}

--- a/container/tomcat85/src/test/java/org/jboss/modcluster/container/tomcat/ServiceLoaderCatalinaFactoryTestCase.java
+++ b/container/tomcat85/src/test/java/org/jboss/modcluster/container/tomcat/ServiceLoaderCatalinaFactoryTestCase.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.modcluster.container.tomcat;
+
+import org.jboss.modcluster.container.catalina.CatalinaFactoryRegistry;
+import org.jboss.modcluster.container.catalina.CatalinaHostFactory;
+
+import static org.junit.Assert.assertSame;
+
+/**
+ * @author Paul Ferraro
+ * @author Radoslav Husar
+ * @version May 2016
+ */
+public class ServiceLoaderCatalinaFactoryTestCase extends org.jboss.modcluster.container.catalina.ServiceLoaderCatalinaFactoryTestCase {
+    @Override
+    protected void verifyCatalinaFactoryTypes(CatalinaFactoryRegistry registry) {
+        assertSame(registry.getServerFactory().getClass(), TomcatServerFactory.class);
+        assertSame(registry.getEngineFactory().getClass(), TomcatEngineFactory.class);
+        assertSame(registry.getHostFactory().getClass(), CatalinaHostFactory.class);
+        assertSame(registry.getContextFactory().getClass(), TomcatContextFactory.class);
+        assertSame(registry.getConnectorFactory().getClass(), TomcatConnectorFactory.class);
+    }
+}

--- a/container/tomcat85/src/test/java/org/jboss/modcluster/container/tomcat/TomcatEventHandlerAdapterTestCase.java
+++ b/container/tomcat85/src/test/java/org/jboss/modcluster/container/tomcat/TomcatEventHandlerAdapterTestCase.java
@@ -1,0 +1,190 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.modcluster.container.tomcat;
+
+import org.apache.catalina.Container;
+import org.apache.catalina.Lifecycle;
+import org.apache.catalina.LifecycleEvent;
+import org.apache.catalina.LifecycleListener;
+import org.apache.catalina.Service;
+import org.jboss.modcluster.container.ContainerEventHandler;
+import org.jboss.modcluster.container.Server;
+import org.jboss.modcluster.container.catalina.CatalinaEventHandler;
+import org.jboss.modcluster.container.catalina.CatalinaFactory;
+import org.jboss.modcluster.container.catalina.ContainerEventHandlerAdapterTestCase;
+import org.jboss.modcluster.container.catalina.ServerProvider;
+import org.mockito.Mockito;
+
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Paul Ferraro
+ * @author Radoslav Husar
+ * @version May 2016
+ */
+public class TomcatEventHandlerAdapterTestCase extends ContainerEventHandlerAdapterTestCase {
+
+    @Override
+    protected CatalinaEventHandler createEventHandler(ContainerEventHandler eventHandler, ServerProvider provider, CatalinaFactory factory) {
+        return new TomcatEventHandlerAdapter(eventHandler, provider, factory);
+    }
+
+    @Override
+    protected LifecycleEvent createAfterInitEvent(Lifecycle lifecycle) {
+        return new LifecycleEvent(lifecycle, Lifecycle.AFTER_INIT_EVENT, null);
+    }
+
+    @Override
+    protected LifecycleEvent createBeforeDestroyInitEvent(Lifecycle lifecycle) {
+        return new LifecycleEvent(lifecycle, Lifecycle.BEFORE_DESTROY_EVENT, null);
+    }
+
+    @Override
+    protected void initServer(CatalinaEventHandler handler, LifecycleServer server) {
+        Service service = mock(Service.class);
+        LifecycleEngine engine = mock(LifecycleEngine.class);
+        Container container = mock(Container.class);
+        LifecycleContainer childContainer = mock(LifecycleContainer.class);
+        Server catalinaServer = mock(Server.class);
+
+        when(server.findServices()).thenReturn(new Service[] { service });
+        when(service.getContainer()).thenReturn(engine);
+        when(engine.findChildren()).thenReturn(new Container[] { container });
+        when(container.findChildren()).thenReturn(new Container[] { childContainer });
+        when(this.factory.createServer(server)).thenReturn(catalinaServer);
+
+        handler.lifecycleEvent(this.createAfterInitEvent(server));
+
+        verify(this.eventHandler).init(same(catalinaServer));
+        verify(engine).addContainerListener(handler);
+        verify(engine).addLifecycleListener(handler);
+        verify(container).addContainerListener(handler);
+        verify(childContainer).addLifecycleListener(handler);
+
+        reset(this.eventHandler);
+    }
+
+
+    @Override
+    public void start() {
+        Service service = mock(Service.class);
+        LifecycleListener listener = mock(LifecycleListener.class);
+        LifecycleEngine engine = mock(LifecycleEngine.class);
+        Container container = mock(Container.class);
+        LifecycleContainer childContainer = mock(LifecycleContainer.class);
+        Server server = mock(Server.class);
+
+        CatalinaEventHandler handler = this.createEventHandler(this.eventHandler, this.provider, this.factory);
+
+        when(this.provider.getServer()).thenReturn(this.server);
+        when(this.server.findLifecycleListeners()).thenReturn(new LifecycleListener[] { listener });
+        when(this.server.findServices()).thenReturn(new Service[] { service });
+        when(service.getContainer()).thenReturn(engine);
+        when(engine.findChildren()).thenReturn(new Container[] { container });
+        when(container.findChildren()).thenReturn(new Container[] { childContainer });
+        when(this.factory.createServer(same(this.server))).thenReturn(server);
+
+        handler.start();
+
+        verify(this.server).addLifecycleListener(same(handler));
+        verify(this.eventHandler).init(same(server));
+        verify(engine).addContainerListener(handler);
+        verify(engine).addLifecycleListener(handler);
+        verify(container).addContainerListener(handler);
+        verify(childContainer).addLifecycleListener(handler);
+        verify(childContainer).addPropertyChangeListener(handler);
+        verify(this.eventHandler).start(same(server));
+    }
+
+    @Override
+    public void stop() throws Exception {
+        Server server = mock(Server.class);
+        Service service = mock(Service.class);
+        LifecycleEngine engine = mock(LifecycleEngine.class);
+        Container container = mock(Container.class);
+        LifecycleContainer childContainer = mock(LifecycleContainer.class);
+
+        CatalinaEventHandler handler = this.createEventHandler(this.eventHandler, this.provider, this.factory);
+
+        this.initServer(handler, this.server);
+        this.startServer(handler, this.server);
+
+        when(this.provider.getServer()).thenReturn(this.server);
+        when(this.server.findServices()).thenReturn(new Service[] { service });
+        when(service.getContainer()).thenReturn(engine);
+        when(engine.findChildren()).thenReturn(new Container[] { container });
+        when(container.findChildren()).thenReturn(new Container[] { childContainer });
+        when(this.factory.createServer(this.server)).thenReturn(server);
+
+        handler.stop();
+
+        verify(this.server).removeLifecycleListener(same(handler));
+        verify(this.eventHandler).stop(same(server));
+        verify(engine).removeContainerListener(handler);
+        verify(engine).removeLifecycleListener(handler);
+        verify(container).removeContainerListener(handler);
+        verify(childContainer).removeLifecycleListener(handler);
+        verify(childContainer).removePropertyChangeListener(handler);
+        verify(this.eventHandler).shutdown();
+    }
+
+    @Override
+    public void destroyServer() throws Exception {
+        CatalinaEventHandler handler = this.createEventHandler(this.eventHandler, this.provider, this.factory);
+
+        LifecycleServer server = mock(LifecycleServer.class);
+        LifecycleEvent event = createBeforeDestroyInitEvent(server);
+
+        handler.lifecycleEvent(event);
+
+        Mockito.verifyZeroInteractions(this.eventHandler);
+
+        this.initServer(handler, server);
+
+        Service service = mock(Service.class);
+        LifecycleEngine engine = mock(LifecycleEngine.class);
+        Container container = mock(Container.class);
+        LifecycleContainer childContainer = mock(LifecycleContainer.class);
+
+        when(server.findServices()).thenReturn(new Service[] { service });
+        when(service.getContainer()).thenReturn(engine);
+        when(engine.findChildren()).thenReturn(new Container[] { container });
+        when(container.findChildren()).thenReturn(new Container[] { childContainer });
+
+        handler.lifecycleEvent(event);
+
+        verify(engine).removeContainerListener(handler);
+        verify(engine).removeLifecycleListener(handler);
+        verify(container).removeContainerListener(handler);
+        verify(childContainer).removeLifecycleListener(handler);
+        verify(this.eventHandler).shutdown();
+        reset(this.eventHandler);
+
+        handler.lifecycleEvent(event);
+
+        Mockito.verifyZeroInteractions(this.eventHandler);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
         <version.tomcat6>6.0.35</version.tomcat6>
         <version.tomcat7>7.0.30</version.tomcat7>
         <version.tomcat8>8.0.21</version.tomcat8>
+        <version.tomcat85>8.5.2</version.tomcat85>
         <version.tomcat9>9.0.0.M4</version.tomcat9>
         <version.jbossweb7>7.2.1.Final</version.jbossweb7>
         <version.http-client>4.2.3</version.http-client>

--- a/src/assembly/bin.xml
+++ b/src/assembly/bin.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<assembly xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/assembly-1.0.0.xsd">
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
   <id>bin</id>
   <formats>
     <format>tar.gz</format>
@@ -120,6 +122,17 @@
     </fileSet>
     <fileSet>
       <directory>container/tomcat8/target/</directory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+      <excludes>
+        <exclude>*-sources.jar</exclude>
+        <exclude>*-tests.jar</exclude>
+      </excludes>
+      <outputDirectory>JBossWeb-Tomcat/lib/</outputDirectory>
+    </fileSet>
+    <fileSet>
+      <directory>container/tomcat85/target/</directory>
       <includes>
         <include>*.jar</include>
       </includes>


### PR DESCRIPTION
Jira
https://issues.jboss.org/browse/MODCLUSTER-493

At this point it's a copy of Tomcat 9 milestone implementation, so there is a chance that for 8.5 the 9 jars could be used. So if people have ideas about how to proceed. Maybe we can have this in as a separate module for now and see how the compatibility evolves; possibly dropping this in the future?