### PR TITLE
MODCLUSTER-463 converts aliases for a context on -APP message arrival.

### DIFF
--- a/native/mod_manager/mod_manager.c
+++ b/native/mod_manager/mod_manager.c
@@ -1577,7 +1577,8 @@ static char * process_appl_cmd(request_rec *r, char **ptr, int status, int *errt
     int i = 0;
     hostinfo_t hostinfo;
     hostinfo_t *host;
-    
+    char *p_tmp;
+
     memset(&nodeinfo.mess, '\0', sizeof(nodeinfo.mess));
     /* Map nothing by default */
     vhost = apr_palloc(r->pool, sizeof(struct cluster_host));
@@ -1598,6 +1599,12 @@ static char * process_appl_cmd(request_rec *r, char **ptr, int status, int *errt
             if (vhost->host) {
                 *errtype = TYPESYNTAX;
                 return SMULALB;
+            }
+            p_tmp = ptr[i+1];
+            /* Aliases to lower case for further case-insensitive treatment, IETF RFC 1035 Section 2.3.3. */
+            while (*p_tmp) {
+                *p_tmp = apr_tolower(*p_tmp);
+                ++p_tmp;
             }
             vhost->host = ptr[i+1];
         }


### PR DESCRIPTION
Unlike tomcat, that makes all aliases lower case even if you configure them upper case, undertow sends aliases verbatim - i.e. even upper case or camel case.

Our logic relies on comparing them, so this PR converts aliases to lower case on arrival.

# Example
From mod_cluster manager console:
## Before
```
</pre><h3>Aliases:</h3><pre>default-host
LOCALHOST
KARM.YADA.YADA.REDHAT.COM
</pre></body></html>
```
## After
```
</pre><h3>Aliases:</h3><pre>default-host
localhost
karm.yada.yada.redhat.com
</pre></body></html>
```