### PR TITLE
[1.3] MODCLUSTER-376 multiple workers with the same id following a tomcat c…

### DIFF
--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -36,6 +36,7 @@
 #include "http_request.h"
 #include "http_protocol.h"
 #include "http_core.h"
+#include "scoreboard.h"
 #include "ap_mpm.h"
 #include "mod_proxy.h"
 
@@ -879,12 +880,15 @@ static void add_balancers_workers(nodeinfo_t *node, apr_pool_t *pool)
 
 /* the worker corresponding to the id, note that we need to compare the shared memory pointer too */
 #if AP_MODULE_MAGIC_AT_LEAST(20101223,1)
-static proxy_worker *get_worker_from_id_stat(proxy_server_conf *conf, int id, proxy_worker_shared *stat)
+static proxy_worker *get_worker_from_id_stat(proxy_server_conf *conf, int id, proxy_worker_shared *stat, nodeinfo_t *node)
 {
     int i;
     char *ptr = conf->balancers->elts;
     int sizeb = conf->balancers->elt_size;
     int sizew = sizeof(proxy_worker *);
+
+    int mpm_generation;
+    ap_mpm_query(AP_MPMQ_GENERATION, &mpm_generation);
 
     for (i = 0; i < conf->balancers->nelts; i++, ptr=ptr+sizeb) {
         int j;
@@ -895,6 +899,18 @@ static proxy_worker *get_worker_from_id_stat(proxy_server_conf *conf, int id, pr
             proxy_worker **worker = (proxy_worker **) ptrw;
             proxy_cluster_helper *helper = (proxy_cluster_helper *) (*worker)->context;
             if ((*worker)->s == stat && helper->index == id) {
+
+                /* Check that the worker is really the one we need */
+                char sport[7];
+                apr_snprintf(sport, sizeof(sport), "%d", (*worker)->s->port);
+                if (strcmp((*worker)->s->scheme, node->mess.Type) ||
+                    strcmp((*worker)->s->hostname, node->mess.Host) ||
+                    strcmp(sport, node->mess.Port)) {
+                    (*worker)->s->index = 0;
+                    mpm_generation--; /* mark old generation that will recreate the process */
+                    continue; /* skip it */
+                }
+
                 return *worker;
             }
         }
@@ -902,7 +918,7 @@ static proxy_worker *get_worker_from_id_stat(proxy_server_conf *conf, int id, pr
     return NULL;
 }
 #else
-static proxy_worker *get_worker_from_id_stat(proxy_server_conf *conf, int id, proxy_worker_stat *stat)
+static proxy_worker *get_worker_from_id_stat(proxy_server_conf *conf, int id, proxy_worker_stat *stat, nodeinfo_t *node)
 {
     int i;
     int sizew = conf->workers->elt_size;
@@ -911,6 +927,18 @@ static proxy_worker *get_worker_from_id_stat(proxy_server_conf *conf, int id, pr
     for (i = 0; i < conf->workers->nelts; i++, ptrw=ptrw+sizew) {
         proxy_worker *worker = (proxy_worker *) ptrw;
         if (worker->id == id && worker->s == stat) {
+
+                /* Check that the worker is really the one we need */
+                char sport[7];
+                apr_snprintf(sport, sizeof(sport), "%d", worker->port);
+                if (strcmp(worker->scheme, node->mess.Type) ||
+                    strcmp(worker->hostname, node->mess.Host) ||
+                    strcmp(sport, node->mess.Port)) {
+                    worker->id = 0;
+                    ap_my_generation--; /* mark old generation that will recreate the process */
+                    continue; /* skip it */
+                }
+
             return worker;
         }
         worker++;
@@ -918,6 +946,33 @@ static proxy_worker *get_worker_from_id_stat(proxy_server_conf *conf, int id, pr
     return NULL;
 }
 #endif
+
+/* read the node and check that it corresponds to the worker */
+static apr_status_t read_node_worker(int id, nodeinfo_t **node, proxy_worker *worker)
+{
+    char sport[7];
+    apr_status_t status = node_storage->read_node(id, node);
+    if (status != APR_SUCCESS)
+        return status;
+#if AP_MODULE_MAGIC_AT_LEAST(20101223,1)
+    apr_snprintf(sport, sizeof(sport), "%d", worker->s->port);
+    if (strcmp(worker->s->scheme, (* node)->mess.Type) ||
+        strcmp(worker->s->hostname, (* node)->mess.Host) ||
+        strcmp(sport, (* node)->mess.Port)) {
+        /* for some reasons it is not the right node */
+        return APR_NOTFOUND;
+    }
+#else
+    apr_snprintf(sport, sizeof(sport), "%d", worker->port);
+    if (strcmp(worker->scheme, (* node)->mess.Type) ||
+        strcmp(worker->hostname, (* node)->mess.Host) ||
+        strcmp(sport, (* node)->mess.Port)) {
+        /* for some reasons it is not the right node */
+        return APR_NOTFOUND;
+    }
+#endif
+    return APR_SUCCESS;
+}
 
 /*
  * Remove a node from the worker conf
@@ -931,9 +986,9 @@ static int remove_workers_node(nodeinfo_t *node, proxy_server_conf *conf, apr_po
     pptr = pptr + node->offset;
 
 #if AP_MODULE_MAGIC_AT_LEAST(20101223,1)
-    worker = get_worker_from_id_stat(conf, node->mess.id, (proxy_worker_shared *) pptr);
+    worker = get_worker_from_id_stat(conf, node->mess.id, (proxy_worker_shared *) pptr, node);
 #else
-    worker = get_worker_from_id_stat(conf, node->mess.id, (proxy_worker_stat *) pptr);
+    worker = get_worker_from_id_stat(conf, node->mess.id, (proxy_worker_stat *) pptr, node);
 #endif
     if (!worker) {
         /* XXX: Another process may use it, can't do: node_storage->remove_node(node); */
@@ -942,7 +997,7 @@ static int remove_workers_node(nodeinfo_t *node, proxy_server_conf *conf, apr_po
     }
 
     /* prevent other threads using it */
-    worker->s->status |= PROXY_WORKER_IN_ERROR;
+    worker->s->status = worker->s->status | PROXY_WORKER_IN_ERROR;
 
     /* apr_reslist_acquired_count */
     i = 0;
@@ -1506,21 +1561,42 @@ static void update_workers_lbstatus(proxy_server_conf *conf, apr_pool_t *pool, s
                 apr_status_t rv;
                 apr_pool_t *rrp;
                 request_rec *rnew;
-                proxy_worker *worker = get_worker_from_id_stat(conf, id[i], stat);
+                proxy_worker *worker;
+                apr_thread_mutex_lock(lock);
+                worker = get_worker_from_id_stat(conf, id[i], stat, ou);
+                apr_thread_mutex_unlock(lock);
                 if (worker == NULL)
                     continue; /* skip it */
 #if AP_MODULE_MAGIC_AT_LEAST(20101223,1)
-                apr_snprintf(sport, sizeof(sport), ":%d", worker->s->port);
+                int mpm_generation;
+                ap_mpm_query(AP_MPMQ_GENERATION, &mpm_generation);
+                apr_snprintf(sport, sizeof(sport), "%d", worker->s->port);
+                if (strcmp(worker->s->scheme, ou->mess.Type) ||
+                    strcmp(worker->s->hostname, ou->mess.Host) ||
+                    strcmp(sport, ou->mess.Port)) {
+                    /* the worker doesn't correspond to the node */
+                    worker->s->index = 0;
+                    mpm_generation--; /* mark old generation that will recreate the process */
+                    continue; /* skip it */
+                }
                 if (strchr(worker->s->hostname, ':') != NULL)
-                    url = apr_pstrcat(pool, worker->s->scheme, "://[", worker->s->hostname, "]", sport, "/", NULL);
+                    url = apr_pstrcat(pool, worker->s->scheme, "://[", worker->s->hostname, "]", ":", sport, "/", NULL);
                 else
-                    url = apr_pstrcat(pool, worker->s->scheme, "://", worker->s->hostname,  sport, "/", NULL);
+                    url = apr_pstrcat(pool, worker->s->scheme, "://", worker->s->hostname, ":", sport, "/", NULL);
 #else
-                apr_snprintf(sport, sizeof(sport), ":%d", worker->port);
+                apr_snprintf(sport, sizeof(sport), "%d", worker->port);
+                if (strcmp(worker->scheme, ou->mess.Type) ||
+                    strcmp(worker->hostname, ou->mess.Host) ||
+                    strcmp(sport, ou->mess.Port)) {
+                    /* the worker doesn't correspond to the node */
+                    worker->id = 0;
+                    ap_my_generation--; /* mark old generation that will recreate the process */ 
+                    continue; /* skip it */
+                }
                 if (strchr(worker->hostname, ':') != NULL)
-                    url = apr_pstrcat(pool, worker->scheme, "://[", worker->hostname, "]", sport, "/", NULL);
+                    url = apr_pstrcat(pool, worker->scheme, "://[", worker->hostname, "]", ":", sport, "/", NULL);
                 else
-                    url = apr_pstrcat(pool, worker->scheme, "://", worker->hostname,  sport, "/", NULL);
+                    url = apr_pstrcat(pool, worker->scheme, "://", worker->hostname, ":", sport, "/", NULL);
 #endif
 
                 apr_pool_create(&rrp, pool);
@@ -1541,6 +1617,10 @@ static void update_workers_lbstatus(proxy_server_conf *conf, apr_pool_t *pool, s
                 rnew->uri = "/";
                 rnew->headers_in = apr_table_make(rnew->pool, 1);
                 rv = proxy_cluster_try_pingpong(rnew, worker, url, conf, ou->mess.ping, ou->mess.timeout);
+
+                if (read_node_worker(id[i], &ou, worker) != APR_SUCCESS)
+                    continue;
+
                 if (rv != APR_SUCCESS) {
                     /* We can't reach the node */
                     worker->s->status |= PROXY_WORKER_IN_ERROR;
@@ -2262,9 +2342,9 @@ static proxy_worker *internal_find_best_byrequests(proxy_balancer *balancer, pro
              * and that can map the context.
              */
 #if AP_MODULE_MAGIC_AT_LEAST(20101223,1)
-            if (node_storage->read_node(worker->s->index, &node) != APR_SUCCESS)
+            if (read_node_worker(worker->s->index, &node, worker) != APR_SUCCESS)
 #else
-            if (node_storage->read_node(worker->id, &node) != APR_SUCCESS)
+            if (read_node_worker(worker->id, &node, worker) != APR_SUCCESS)
 #endif
                 continue; /* Can't read node */
 
@@ -2292,9 +2372,9 @@ static proxy_worker *internal_find_best_byrequests(proxy_balancer *balancer, pro
                         int lbstatus, lbstatus1;
 
 #if AP_MODULE_MAGIC_AT_LEAST(20101223,1)
-                        if (node_storage->read_node(mycandidate->s->index, &node1) != APR_SUCCESS)
+                        if (read_node_worker(mycandidate->s->index, &node1, mycandidate) != APR_SUCCESS)
 #else
-                        if (node_storage->read_node(mycandidate->id, &node1) != APR_SUCCESS)
+                        if (read_node_worker(mycandidate->id, &node1, mycandidate) != APR_SUCCESS)
 #endif
                             continue;
                         lbstatus1 = ((mycandidate->s->elected - node1->mess.oldelected) * 1000)/mycandidate->s->lbfactor;
@@ -2401,7 +2481,7 @@ static int proxy_node_isup(request_rec *r, int id, int load)
         void *sconf = s->module_config;
         conf = (proxy_server_conf *) ap_get_module_config(sconf, &proxy_module);
 
-        worker = get_worker_from_id_stat(conf, id, stat);
+        worker = get_worker_from_id_stat(conf, id, stat, node);
         if (worker != NULL)
             break;
         s = s->next;
@@ -3280,8 +3360,8 @@ static proxy_worker *find_route_worker(request_rec *r,
                 if (worker && PROXY_WORKER_IS_USABLE(worker)) {
                     /* The context may not be available */
                     nodeinfo_t *node;
-                    if (node_storage->read_node(index, &node) != APR_SUCCESS)
-                        return NULL; /* can't read node */
+                    if (read_node_worker(index, &node, worker) != APR_SUCCESS)
+                       continue;
                     if ((nodecontext = context_host_ok(r, balancer, index, vhost_table, context_table, node_table)) != NULL) {
                         apr_table_setn(r->subprocess_env, "BALANCER_CONTEXT_ID", apr_psprintf(r->pool, "%d", (*nodecontext).context));
                         return worker;


### PR DESCRIPTION
…rash/kill

(cherry picked from commit 66407362716d01089c16a7aa909b2c844c978593)

Heavily modified for httpd 2.4.x mpm_generation API.
- See [MODCLUSTER-376](https://issues.jboss.org/browse/MODCLUSTER-376) for the original synopsis
- Lemme draw @aogburn's and @jfclere's attention especially to sanity of this construct in httpd 2.4:

```
int mpm_generation;
ap_mpm_query(AP_MPMQ_GENERATION, &mpm_generation);
mpm_generation--;
```
### What was tested
- simple JVMKill failover among 3 Tomcat nodes
- various JVMRoute/IP/port/schema substitutions on the fly, letting mod_proxy_cluster to enter the `mpm_generation--;` branch of code
- it doesn't segfault, but it leaves me worried still; I have no idea whether this is a good practise in httpd 2.4

Please, share your thoughts.
