### PR TITLE
MODCLUSTER-497 MODCLUSTER-498 Tomcat modeler fixes and code cleanup:

### DIFF
--- a/core/src/main/java/org/jboss/modcluster/ModClusterServiceMBean.java
+++ b/core/src/main/java/org/jboss/modcluster/ModClusterServiceMBean.java
@@ -25,17 +25,17 @@ import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import org.jboss.modcluster.mcmp.MCMPHandler;
 import org.jboss.modcluster.mcmp.MCMPRequestType;
 
 /**
  * @author Paul Ferraro
- * 
  */
 public interface ModClusterServiceMBean {
     /**
      * Add a proxy to the list of those with which this handler communicates. Communication does not begin until the next call
-     * to {@link #status()}.
-     * 
+     * to {@link MCMPHandler#status()}.
+     *
      * @param host the hostname of the proxy; a string suitable for passing to <code>InetAddress.getByHost(...)</code>
      * @param port the port on which the proxy listens for MCMP requests
      */
@@ -43,8 +43,8 @@ public interface ModClusterServiceMBean {
 
     /**
      * Remove a proxy from the list of those with which this handler communicates. Communication does not end until the next
-     * call to {@link #status()}.
-     * 
+     * call to {@link MCMPHandler#status()}.
+     *
      * @param host the hostname of the proxy; a string suitable for passing to <code>InetAddress.getByHost(...)</code>
      * @param port the port on which the proxy listens for MCMP requests
      */
@@ -52,29 +52,29 @@ public interface ModClusterServiceMBean {
 
     /**
      * Retrieves the full proxy configuration.
-     * 
+     *
      * response: node: [1:1] JVMRoute: node1 Domain: [bla] Host: 127.0.0.1 Port: 8009 Type: ajp host: 1 [] vhost: 1 node: 1
      * context: 1 [/] vhost: 1 node: 1 status: 1 context: 2 [/myapp] vhost: 1 node: 1 status: 1 context: 3 [/host-manager]
      * vhost: 1 node: 1 status: 1 context: 4 [/docs] vhost: 1 node: 1 status: 1 context: 5 [/manager] vhost: 1 node: 1 status: 1
-     * 
+     *
      * Sends a {@link MCMPRequestType#DUMP DUMP} request to all proxies, returning the responses grouped by proxy address.
-     * 
+     *
      * @return a map of DUMP_RSP responses, grouped by proxy
      */
     Map<InetSocketAddress, String> getProxyConfiguration();
 
     /**
      * Retrieves the full proxy info message.
-     * 
+     *
      * Sends an {@link MCMPRequestType#INFO INFO} request to all proxies, returning the responses grouped by proxy address.
-     * 
+     *
      * @return a map of INFO_RSP responses, grouped by proxy
      */
     Map<InetSocketAddress, String> getProxyInfo();
 
     /**
      * Ping httpd. determines whether each proxy is accessible and healthy. returning the PING_RSP grouped by proxy address.
-     * 
+     *
      * @return a map of PING_RSP responses, grouped by proxy
      */
     Map<InetSocketAddress, String> ping();
@@ -82,7 +82,7 @@ public interface ModClusterServiceMBean {
     /**
      * Ping a node from httpd. returning the PING_RSP grouped by proxy address. determines whether the node configured with the
      * specified jvm route is accessible from each proxy returning the PING_RSP grouped by proxy address.
-     * 
+     *
      * @param jvmRoute a jvm route.
      * @return a map of PING_RSP responses, grouped by proxy
      */
@@ -91,9 +91,9 @@ public interface ModClusterServiceMBean {
     /**
      * Ping a node defined protocol, host and port from httpd. determines whether a node (not necessarily configured) with the
      * matching connector is accessible from each proxy
-     * 
-     * @param scheme (ajp, http or https)
-     * @param hostname (name or ip of a the host)
+     *
+     * @param scheme ajp, http or https
+     * @param hostname name or IP of a the host
      * @param port
      * @return a map of PING_RSP responses, grouped by proxy
      */
@@ -111,14 +111,14 @@ public interface ModClusterServiceMBean {
 
     /**
      * Disable all webapps for all engines.
-     * 
+     *
      * @return true, if all proxies are responding normally, false otherwise
      */
     boolean disable();
 
     /**
      * Enable all webapps for all engines.
-     * 
+     *
      * @return true, if all proxies are responding normally, false otherwise
      */
     boolean enable();
@@ -130,7 +130,7 @@ public interface ModClusterServiceMBean {
      * <li>Waits for all sessions to drain</li>
      * <li>Stops all contexts</li>
      * </ol>
-     * 
+     *
      * @param timeout number of units of time for which to wait for sessions to drain. Negative or zero timeout value will wait
      *        forever.
      * @param unit unit of time represented in timeout parameter
@@ -140,7 +140,7 @@ public interface ModClusterServiceMBean {
 
     /**
      * Disables the webapp with the specified host and context path.
-     * 
+     *
      * @param hostName host name of the target webapp
      * @param contextPath context path of the target webapp
      * @return true, if all proxies are responding normally, false otherwise
@@ -149,7 +149,7 @@ public interface ModClusterServiceMBean {
 
     /**
      * Enables the webapp with the specified host and context path.
-     * 
+     *
      * @param hostName host name of the target webapp
      * @param contextPath context path of the target webapp
      * @return true, if all proxies are responding normally, false otherwise
@@ -163,7 +163,7 @@ public interface ModClusterServiceMBean {
      * <li>Waits for all sessions for the specified context to drain</li>
      * <li>Stops the specified context</li>
      * </ol>
-     * 
+     *
      * @param timeout number of units of time for which to wait for sessions to drain. Negative or zero timeout value will wait
      *        forever.
      * @param unit unit of time represented in timeout parameter

--- a/core/src/main/java/org/jboss/modcluster/config/impl/SessionDrainingStrategyEnum.java
+++ b/core/src/main/java/org/jboss/modcluster/config/impl/SessionDrainingStrategyEnum.java
@@ -37,17 +37,15 @@ public enum SessionDrainingStrategyEnum implements SessionDrainingStrategy {
 
     private final Boolean drainSessions;
 
-    private SessionDrainingStrategyEnum(Boolean drainSessions) {
+    SessionDrainingStrategyEnum(Boolean drainSessions) {
         this.drainSessions = drainSessions;
     }
 
     /**
-     * {@inheritDoc}
-     * 
-     * @see org.jboss.modcluster.SessionDrainingStrategy#isEnabled(org.jboss.modcluster.Context)
+     * @see SessionDrainingStrategy#isEnabled(org.jboss.modcluster.container.Context)
      */
     @Override
     public boolean isEnabled(Context context) {
-        return (this.drainSessions != null) ? this.drainSessions.booleanValue() : !context.isDistributable();
+        return (this.drainSessions != null) ? this.drainSessions : !context.isDistributable();
     }
 }


### PR DESCRIPTION
Does the following:
* MODCLUSTER-498 Extract Tomcat modeler specific methods from ModClusterConfig into separate Tomcat-specific class
* MODCLUSTER-497 ModClusterConfig#setAdvertiseInterface(java.lang.String) should not have been deprecated as it's used by Tomcat modeller

by moving the classes from core into base container implementation for Tomcat.

Jiras
https://issues.jboss.org/browse/MODCLUSTER-498
https://issues.jboss.org/browse/MODCLUSTER-497

Just to note, wildfly master still relies on the following "deprecated" 2 methods that are being moved (so dropping in widlfly wont work, but shouldn't be a problem).
```
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR :
[INFO] -------------------------------------------------------------
[ERROR] /Users/rhusar/wildfly/mod_cluster/extension/src/main/java/org/wildfly/extension/mod_cluster/ModClusterSubsystemAdd.java:[245,19] cannot find symbol
  symbol:   method setExcludedContexts(java.lang.String)
  location: variable config of type org.jboss.modcluster.config.impl.ModClusterConfig
[ERROR] /Users/rhusar/wildfly/mod_cluster/extension/src/main/java/org/wildfly/extension/mod_cluster/ModClusterSubsystemAdd.java:[265,115] incompatible types: java.lang.String cannot be converted to org.jboss.modcluster.config.SessionDrainingStrategy
[INFO] 2 errors
```
The session draining was reaadded via https://github.com/modcluster/mod_cluster/commit/37824e766d690eff4c5059da1f0e64861ca3adea, bunch of other stuff via fix for https://bugzilla.redhat.com/show_bug.cgi?id=822250