### PR TITLE
MODCLUSTER-528 Allow building base for tomcat container implementatio…

### DIFF
--- a/container/tomcat/pom.xml
+++ b/container/tomcat/pom.xml
@@ -113,6 +113,7 @@
                 </dependency>
             </dependencies>
         </profile>
+        -->
         <profile>
             <id>TC8</id>
             <activation>
@@ -145,7 +146,6 @@
                 </dependency>
             </dependencies>
         </profile>
-        -->
         <profile>
             <id>TC7</id>
             <activation>


### PR DESCRIPTION
…n (tomcat module) solely with tomcat8 dependencies (-PTC8)

This is more of a workaround to enable building with tomcat8 only dependencies. I am reluctant to allow this, but its needed for building RPM for Fedora 24 (as brought up by @Karm) which only provides tomcat8 package. I am definitely not allowing building for tomcat85 and tomcat9 dependencies as this will not compile and more patching would be needed.