### PR TITLE
MODCLUSTER-534 update to MODCLUSTER-435 normalizing balancer name

### DIFF
--- a/native/mod_manager/mod_manager.c
+++ b/native/mod_manager/mod_manager.c
@@ -60,6 +60,9 @@
 #define DEFMAXJGROUPSID  0
 #define MAXMESSSIZE     1024
 
+/* Warning messages */
+#define SBALBAD "Balancer name contained an upper case character. We will use \"%s\" instead."
+
 /* Error messages */
 #define TYPESYNTAX 1
 #define SMESPAR "SYNTAX: Can't parse MCMP message. It might have contained illegal symbols or unknown elements."
@@ -490,7 +493,7 @@ void normalize_balancer_name(char* balancer_name, server_rec *s)
     }
     balancer_name = balancer_name_start;
     if(upper_case_char_found) {
-        ap_log_error(APLOG_MARK, APLOG_NOERRNO|APLOG_WARNING, 0, s, "Balancer name contained an upper case character. We will use %s instead.", balancer_name);
+        ap_log_error(APLOG_MARK, APLOG_NOERRNO|APLOG_WARNING, 0, s, SBALBAD, balancer_name);
     }
 }
 
@@ -852,6 +855,7 @@ static char * process_config(request_rec *r, char **ptr, int *errtype)
                 *errtype = TYPESYNTAX;
                 return SBALBIG;
             }
+            normalize_balancer_name(ptr[i+1], r->server);
             strncpy(nodeinfo.mess.balancer, ptr[i+1], sizeof(nodeinfo.mess.balancer));
             nodeinfo.mess.balancer[sizeof(nodeinfo.mess.balancer) - 1] = '\0';
             strncpy(balancerinfo.balancer, ptr[i+1], sizeof(balancerinfo.balancer));


### PR DESCRIPTION
We need mod_cluster and its underlying mod_proxy code to work well with various crazy Balancer names. Back in the day, upper case characters in Balancer name were fixed for ```ManagerBalancerName``` static configuration, see:

 * [~~MODCLUSTER-435~~](https://issues.jboss.org/browse/MODCLUSTER-435)
 * [~~BZ 1044879~~](https://bugzilla.redhat.com/show_bug.cgi?id=1044879#c0)

A new issue has surfaced, [MODCLUSTER-534](https://issues.jboss.org/browse/MODCLUSTER-534), that concerns Balancer names coming in CONFIG messages from workers. This fix expands [~~MODCLUSTER-435~~](https://issues.jboss.org/browse/MODCLUSTER-435) to cover  [MODCLUSTER-534](https://issues.jboss.org/browse/MODCLUSTER-534).