### PR TITLE
MODCLUSTER-560 Upgrade mockito to 2.5.2

### DIFF
--- a/container/tomcat/src/test/java/org/jboss/modcluster/container/catalina/AutoProxyConnectorProviderTestCase.java
+++ b/container/tomcat/src/test/java/org/jboss/modcluster/container/catalina/AutoProxyConnectorProviderTestCase.java
@@ -1,7 +1,7 @@
 package org.jboss.modcluster.container.catalina;
 
 import static org.junit.Assert.assertSame;
-import static org.mockito.Matchers.same;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/container/tomcat/src/test/java/org/jboss/modcluster/container/catalina/ContainerEventHandlerAdapterTestCase.java
+++ b/container/tomcat/src/test/java/org/jboss/modcluster/container/catalina/ContainerEventHandlerAdapterTestCase.java
@@ -21,7 +21,7 @@
  */
 package org.jboss.modcluster.container.catalina;
 
-import static org.mockito.Matchers.same;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;

--- a/container/tomcat/src/test/java/org/jboss/modcluster/container/catalina/ContextTestCase.java
+++ b/container/tomcat/src/test/java/org/jboss/modcluster/container/catalina/ContextTestCase.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.same;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/container/tomcat/src/test/java/org/jboss/modcluster/container/catalina/JMXServerProviderTestCase.java
+++ b/container/tomcat/src/test/java/org/jboss/modcluster/container/catalina/JMXServerProviderTestCase.java
@@ -2,9 +2,9 @@ package org.jboss.modcluster.container.catalina;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isNull;
-import static org.mockito.Matchers.same;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/container/tomcat/src/test/java/org/jboss/modcluster/container/catalina/ServerTestCase.java
+++ b/container/tomcat/src/test/java/org/jboss/modcluster/container/catalina/ServerTestCase.java
@@ -24,7 +24,7 @@ package org.jboss.modcluster.container.catalina;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.same;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/container/tomcat/src/test/java/org/jboss/modcluster/container/catalina/SimpleProxyConnectorProviderTestCase.java
+++ b/container/tomcat/src/test/java/org/jboss/modcluster/container/catalina/SimpleProxyConnectorProviderTestCase.java
@@ -1,7 +1,7 @@
 package org.jboss.modcluster.container.catalina;
 
 import static org.junit.Assert.assertSame;
-import static org.mockito.Matchers.same;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/container/tomcat85/src/test/java/org/jboss/modcluster/container/tomcat85/ServerTestCase.java
+++ b/container/tomcat85/src/test/java/org/jboss/modcluster/container/tomcat85/ServerTestCase.java
@@ -32,7 +32,7 @@ import java.util.Iterator;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.same;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/container/tomcat85/src/test/java/org/jboss/modcluster/container/tomcat85/TomcatEventHandlerAdapterTestCase.java
+++ b/container/tomcat85/src/test/java/org/jboss/modcluster/container/tomcat85/TomcatEventHandlerAdapterTestCase.java
@@ -33,7 +33,7 @@ import org.jboss.modcluster.container.tomcat.TomcatEventHandler;
 import org.jboss.modcluster.container.tomcat.TomcatFactory;
 import org.mockito.Mockito;
 
-import static org.mockito.Matchers.same;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;

--- a/core/src/test/java/org/jboss/modcluster/load/metric/MBeanAttributeLoadMetricTestCase.java
+++ b/core/src/test/java/org/jboss/modcluster/load/metric/MBeanAttributeLoadMetricTestCase.java
@@ -22,8 +22,8 @@
 package org.jboss.modcluster.load.metric;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.isNull;
-import static org.mockito.Matchers.same;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/core/src/test/java/org/jboss/modcluster/load/metric/MBeanAttributeRatioLoadMetricTestCase.java
+++ b/core/src/test/java/org/jboss/modcluster/load/metric/MBeanAttributeRatioLoadMetricTestCase.java
@@ -22,8 +22,8 @@
 package org.jboss.modcluster.load.metric;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.isNull;
-import static org.mockito.Matchers.same;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.jfreechart>1.0.13</version.jfreechart>
         <version.jcip-annotations>1.0</version.jcip-annotations>
         <version.junit>4.10</version.junit>
-        <version.mockito>1.9.0</version.mockito>
+        <version.mockito>2.5.2</version.mockito>
         <version.javax.servlet-3.0>1.0.2.Final</version.javax.servlet-3.0>
     </properties>
 


### PR DESCRIPTION
Jira
https://issues.jboss.org/browse/MODCLUSTER-560

Needed for JDK9 support.
