### PR TITLE
[1.3] MODCLUSTER-566 Exclusion list cannot be pre-populated in init()

### DIFF
--- a/core/src/main/java/org/jboss/modcluster/mcmp/ContextFilter.java
+++ b/core/src/main/java/org/jboss/modcluster/mcmp/ContextFilter.java
@@ -21,7 +21,6 @@
  */
 package org.jboss.modcluster.mcmp;
 
-import java.util.Map;
 import java.util.Set;
 
 import org.jboss.modcluster.container.Host;
@@ -31,16 +30,16 @@ import org.jboss.modcluster.container.Host;
  */
 public interface ContextFilter {
     /**
-     * Returns the contexts that will *not* be registered in any proxy.
-     * 
-     * @return a set of context paths per host
+     * Returns the contexts that will *not* be registered in any proxy for the given host.
+     *
+     * @return a set of context paths excluded for the given host
      */
-    Map<Host, Set<String>> getExcludedContexts();
+    Set<String> getExcludedContexts(Host host);
 
     /**
      * Indicates when contexts should auto-enable by default. If auto-enable is off, then contexts are disabled by default and
      * must be enabled manually.
-     * 
+     *
      * @return true, contexts should be auto-enabled, false otherwise.
      */
     boolean isAutoEnableContexts();

--- a/core/src/main/java/org/jboss/modcluster/mcmp/impl/ResetRequestSourceImpl.java
+++ b/core/src/main/java/org/jboss/modcluster/mcmp/impl/ResetRequestSourceImpl.java
@@ -80,7 +80,6 @@ public class ResetRequestSourceImpl implements ResetRequestSource {
         if (this.server == null)
             return requests;
 
-        Map<Host, Set<String>> excludedContexts = this.contextFilter.getExcludedContexts();
         boolean contextAutoEnableAllowed = this.contextFilter.isAutoEnableContexts();
 
         List<MCMPRequest> engineRequests = new LinkedList<MCMPRequest>();
@@ -120,7 +119,7 @@ public class ResetRequestSourceImpl implements ResetRequestSource {
                 }
 
                 Set<String> obsoleteContexts = new HashSet<String>(responseContexts.keySet());
-                Set<String> excludedHostContexts = excludedContexts.get(host);
+                Set<String> excludedHostContexts = this.contextFilter.getExcludedContexts(host);
 
                 for (Context context : host.getContexts()) {
                     String contextPath = context.getPath();

--- a/core/src/test/java/org/jboss/modcluster/mcmp/ResetRequestSourceTestCase.java
+++ b/core/src/test/java/org/jboss/modcluster/mcmp/ResetRequestSourceTestCase.java
@@ -78,8 +78,7 @@ public class ResetRequestSourceTestCase {
         MCMPRequest configRequest = mock(MCMPRequest.class);
         MCMPRequest contextRequest = mock(MCMPRequest.class);
 
-        when(contextFilter.getExcludedContexts())
-                .thenReturn(Collections.singletonMap(host, Collections.singleton("/excluded")));
+        when(contextFilter.getExcludedContexts(host)).thenReturn(Collections.singleton("/excluded"));
         when(contextFilter.isAutoEnableContexts()).thenReturn(true);
 
         when(server.getEngines()).thenReturn(Collections.singleton(engine));
@@ -124,8 +123,7 @@ public class ResetRequestSourceTestCase {
         MCMPRequest configRequest = mock(MCMPRequest.class);
         MCMPRequest contextRequest = mock(MCMPRequest.class);
 
-        when(contextFilter.getExcludedContexts())
-                .thenReturn(Collections.singletonMap(host, Collections.singleton("/excluded")));
+        when(contextFilter.getExcludedContexts(host)).thenReturn(Collections.singleton("/excluded"));
         when(contextFilter.isAutoEnableContexts()).thenReturn(false);
 
         when(server.getEngines()).thenReturn(Collections.singleton(engine));


### PR DESCRIPTION
Jira
https://issues.jboss.org/browse/MODCLUSTER-566

Upstream
https://github.com/modcluster/mod_cluster/pull/241