### PR TITLE
MODCLUSTER-574 Allow custom LoadMetric implementations to put node in…

### DIFF
--- a/core/src/main/java/org/jboss/modcluster/load/metric/NodeUnavailableException.java
+++ b/core/src/main/java/org/jboss/modcluster/load/metric/NodeUnavailableException.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2009, Red Hat Middleware LLC, and individual contributors
+ * Copyright 2017, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,25 +19,14 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
+
 package org.jboss.modcluster.load.metric;
 
-import org.jboss.modcluster.container.Engine;
-
 /**
- * Represents a specific load metric.
- * 
- * @author Paul Ferraro
+ * Exception thrown by {@link LoadMetric} implementations to indicate that the node should be put into error state.
+ * If any of the metrics throws this exception, no further metrics are queried and node is put into error state (-1).
+ *
+ * @author Radoslav Husar
  */
-public interface LoadMetric extends LoadMetricMBean {
-    double DEFAULT_CAPACITY = 1;
-    int DEFAULT_WEIGHT = 1;
-
-    /**
-     * Returns the current load of this metric as a percent of the metric's capacity.
-     * 
-     * @return raw load / capacity.
-     * @throws NodeUnavailableException if the node should be put into the error state.
-     * @throws Exception if the load could not be determined.
-     */
-    double getLoad(Engine engine) throws Exception;
+public class NodeUnavailableException extends Exception {
 }

--- a/core/src/test/java/org/jboss/modcluster/load/impl/DynamicLoadBalanceFactorProviderTest.java
+++ b/core/src/test/java/org/jboss/modcluster/load/impl/DynamicLoadBalanceFactorProviderTest.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.modcluster.load.impl;
+
+import org.jboss.modcluster.container.Engine;
+import org.jboss.modcluster.load.metric.LoadMetric;
+import org.jboss.modcluster.load.metric.NodeUnavailableException;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Radoslav Husar
+ */
+public class DynamicLoadBalanceFactorProviderTest {
+
+    @Test
+    public void getLoadBalanceFactor() throws Exception {
+        Engine engine = mock(Engine.class);
+
+        Set<LoadMetric> metrics = new HashSet<>();
+        LoadMetric metric = mock(LoadMetric.class);
+        when(metric.getWeight()).thenReturn(LoadMetric.DEFAULT_WEIGHT);
+        when(metric.getLoad(engine)).thenThrow(new NodeUnavailableException());
+        metrics.add(metric);
+
+        DynamicLoadBalanceFactorProvider provider = new DynamicLoadBalanceFactorProvider(metrics);
+
+        int loadBalanceFactor = provider.getLoadBalanceFactor(engine);
+        assertEquals(-1, loadBalanceFactor);
+    }
+
+}


### PR DESCRIPTION
…to error state (load of -1); cleanup unnecessary boxing/unboxing

https://issues.jboss.org/browse/MODCLUSTER-574