### PR TITLE
MODCLUSTER-561 Upgrade maven-war-plugin to version compatible with JDK 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,9 @@
         <version.junit>4.10</version.junit>
         <version.mockito>2.5.2</version.mockito>
         <version.javax.servlet-3.0>1.0.2.Final</version.javax.servlet-3.0>
+
+        <!-- Override version 2.6 managed by org.jboss:jboss-parent:21 which works with JDK9 -->
+        <version.war.plugin>3.1.0</version.war.plugin>
     </properties>
 
     <dependencyManagement>
@@ -159,6 +162,11 @@
             </resource>
         </resources>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>${version.war.plugin}</version>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>21</version>
+        <version>22</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -72,7 +72,7 @@
         <version.mockito>2.5.2</version.mockito>
         <version.javax.servlet-3.0>1.0.2.Final</version.javax.servlet-3.0>
 
-        <!-- Override version 2.6 managed by org.jboss:jboss-parent:21 which works with JDK9 -->
+        <!-- Override version 3.0.0 managed by org.jboss:jboss-parent:22 which works with JDK9 -->
         <version.war.plugin>3.1.0</version.war.plugin>
     </properties>
 


### PR DESCRIPTION
Jira
https://issues.jboss.org/browse/MODCLUSTER-561
https://issues.jboss.org/browse/MODCLUSTER-586

Now mod_cluster builds on JDK9 including the demo!