### PR TITLE
MODCLUSTER-585 mod_cluster excluded-contexts doesn't exclude slash prefixed /contexts; should perform normalization

### DIFF
--- a/container/tomcat/pom.xml
+++ b/container/tomcat/pom.xml
@@ -41,11 +41,6 @@
             <artifactId>mod_cluster-container-spi</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
     <profiles>
         <!--

--- a/container/tomcat/src/main/java/org/jboss/modcluster/container/tomcat/ModClusterListener.java
+++ b/container/tomcat/src/main/java/org/jboss/modcluster/container/tomcat/ModClusterListener.java
@@ -474,7 +474,19 @@ public class ModClusterListener extends ModClusterConfig implements LifecycleLis
                         trimmedContext = parts[1].trim();
                     }
 
-                    String path = trimmedContext.equals(ROOT_CONTEXT) ? "" : "/" + trimmedContext;
+                    String path;
+                    switch (trimmedContext) {
+                        case "ROOT":
+                            log.warn("Value 'ROOT' for excludedContexts is deprecated, to exclude the root context use '/' instead.");
+                        case "/":
+                            path = "";
+                            break;
+                        default:
+                            // normalize the context by pre-pending or removing trailing slash
+                            trimmedContext = trimmedContext.startsWith("/") ? trimmedContext : ("/" + trimmedContext);
+                            path = trimmedContext.endsWith("/") ? trimmedContext.substring(0, trimmedContext.length() - 1) : trimmedContext;
+                            break;
+                    }
 
                     Set<String> paths = excludedContextsPerHost.get(host);
 


### PR DESCRIPTION
Jira
https://issues.jboss.org/browse/MODCLUSTER-585 - the tomcat part

