### PR TITLE
[1.3] MODCLUSTER-596 mod_cluster stop/stop-context operations do not send S…

### DIFF
--- a/core/src/main/java/org/jboss/modcluster/ModClusterService.java
+++ b/core/src/main/java/org/jboss/modcluster/ModClusterService.java
@@ -691,12 +691,13 @@ public class ModClusterService implements ModClusterServiceMBean, ContainerEvent
 
         long start = System.currentTimeMillis();
         long end = start + unit.toMillis(timeout);
+        boolean success = true;
 
         for (Engine engine : this.server.getEngines()) {
             for (Host host : engine.getHosts()) {
                 for (Context context : host.getContexts()) {
                     if (this.mcmpConfig.getSessionDrainingStrategy().isEnabled(context) && !this.drainSessions(context, start, end)) {
-                        return false;
+                        success = false;
                     }
                 }
             }
@@ -707,7 +708,7 @@ public class ModClusterService implements ModClusterServiceMBean, ContainerEvent
             this.mcmpHandler.sendRequest(this.requestFactory.createStopRequest(engine));
         }
 
-        return true;
+        return success;
     }
 
     /**
@@ -733,9 +734,7 @@ public class ModClusterService implements ModClusterServiceMBean, ContainerEvent
             success = this.drainSessions(context, start, start + unit.toMillis(timeout));
         }
 
-        if (success) {
-            this.mcmpHandler.sendRequest(this.requestFactory.createStopRequest(context));
-        }
+        this.mcmpHandler.sendRequest(this.requestFactory.createStopRequest(context));
 
         return success;
     }


### PR DESCRIPTION
…TOP-* in when session draining was unsuccessful

https://issues.jboss.org/browse/MODCLUSTER-596
https://github.com/modcluster/mod_cluster/pull/264