### PR TITLE
[MODCLUSTER-584] Enclose IPv6 address into square brackets

### DIFF
--- a/core/src/main/java/org/jboss/modcluster/mcmp/impl/DefaultMCMPHandler.java
+++ b/core/src/main/java/org/jboss/modcluster/mcmp/impl/DefaultMCMPHandler.java
@@ -600,7 +600,7 @@ public class DefaultMCMPHandler implements MCMPHandler {
         synchronized (proxy) {
             try {
                 String line = null;
-                String host = proxy.getSocketAddress().getHostName();
+                String host = proxy.getSocketAddress().getHostString();
                 String proxyhead;
 
                 if(host != null && host.contains(":")) {

--- a/core/src/main/java/org/jboss/modcluster/mcmp/impl/DefaultMCMPHandler.java
+++ b/core/src/main/java/org/jboss/modcluster/mcmp/impl/DefaultMCMPHandler.java
@@ -600,7 +600,15 @@ public class DefaultMCMPHandler implements MCMPHandler {
         synchronized (proxy) {
             try {
                 String line = null;
-                String proxyhead = head + proxy.getSocketAddress().getHostName() + ":" + proxy.getSocketAddress().getPort();
+                String host = proxy.getSocketAddress().getHostName();
+                String proxyhead;
+
+                if(host != null && host.contains(":")) {
+                    proxyhead = head + "[" + host + "]:" + proxy.getSocketAddress().getPort();
+                } else {
+                    proxyhead = head + host + ":" + proxy.getSocketAddress().getPort();
+                }
+
                 try {
                     line = sendRequest(proxy, proxyhead, body);
                 } catch (IOException e) {


### PR DESCRIPTION
Enclose IPv6 address into square brackets while sending STATUS info to balancer.

MODCLUSTER-584: https://issues.jboss.org/browse/MODCLUSTER-584

@rhusar - seems that modcluster is trying to resolve IP address to hostname (seems it's another suspect for the automagic plague)
