### PR TITLE
[1.3] MODCLUSTER-620 Travis CI: workaround dropping openjdk6/oraclejdk7 on …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,18 @@
 language: java
 jdk:
   - oraclejdk8
-  - oraclejdk7
   - openjdk7
 script: mvn verify -Pdist
 matrix:
   include:
   - jdk: openjdk6
+    # Workaround https://github.com/travis-ci/travis-ci/issues/8199
+    dist: precise
     script: mvn verify -Pdist -pl !container/tomcat8
+  # Workaround travis dropping oraclejdk7 on stable/trusty
+  # https://github.com/travis-ci/travis-ci/issues/7884#issuecomment-308451879
+  - jdk: oraclejdk7
+    dist: precise
 notifications:
   email: false
 # Workaround openjdk6/7 crashes in container-based environments failing with:


### PR DESCRIPTION
…stable/trusty