### PR TITLE
MODCLUSTER-469 Tomcat 8 container integration does not add jvm-route …

### DIFF
--- a/container/tomcat8/src/main/java/org/jboss/modcluster/container/tomcat8/TomcatContext.java
+++ b/container/tomcat8/src/main/java/org/jboss/modcluster/container/tomcat8/TomcatContext.java
@@ -22,6 +22,8 @@
 package org.jboss.modcluster.container.tomcat8;
 
 import org.apache.catalina.Context;
+import org.apache.catalina.Manager;
+import org.apache.catalina.SessionIdGenerator;
 import org.apache.catalina.Valve;
 import org.apache.catalina.comet.CometEvent;
 import org.apache.catalina.connector.Request;
@@ -38,7 +40,6 @@ import java.io.IOException;
 /**
  * @author Paul Ferraro
  * @author Radoslav Husar
- * @version Nov 2014
  */
 public class TomcatContext extends org.jboss.modcluster.container.tomcat.TomcatContext {
 
@@ -94,6 +95,16 @@ public class TomcatContext extends org.jboss.modcluster.container.tomcat.TomcatC
             RequestListenerValve valve = (RequestListenerValve) object;
 
             return this.listener == valve.listener;
+        }
+    }
+
+    void setJvmRoute(String jvmRoute) {
+        Manager contextManager = context.getManager();
+        if (contextManager != null) {
+            SessionIdGenerator sessionIdGenerator = contextManager.getSessionIdGenerator();
+            if (sessionIdGenerator != null) {
+                sessionIdGenerator.setJvmRoute(jvmRoute);
+            }
         }
     }
 }

--- a/container/tomcat8/src/main/java/org/jboss/modcluster/container/tomcat8/TomcatContext.java
+++ b/container/tomcat8/src/main/java/org/jboss/modcluster/container/tomcat8/TomcatContext.java
@@ -22,8 +22,6 @@
 package org.jboss.modcluster.container.tomcat8;
 
 import org.apache.catalina.Context;
-import org.apache.catalina.Manager;
-import org.apache.catalina.SessionIdGenerator;
 import org.apache.catalina.Valve;
 import org.apache.catalina.comet.CometEvent;
 import org.apache.catalina.connector.Request;
@@ -95,16 +93,6 @@ public class TomcatContext extends org.jboss.modcluster.container.tomcat.TomcatC
             RequestListenerValve valve = (RequestListenerValve) object;
 
             return this.listener == valve.listener;
-        }
-    }
-
-    void setJvmRoute(String jvmRoute) {
-        Manager contextManager = context.getManager();
-        if (contextManager != null) {
-            SessionIdGenerator sessionIdGenerator = contextManager.getSessionIdGenerator();
-            if (sessionIdGenerator != null) {
-                sessionIdGenerator.setJvmRoute(jvmRoute);
-            }
         }
     }
 }

--- a/container/tomcat8/src/main/java/org/jboss/modcluster/container/tomcat8/TomcatEngine.java
+++ b/container/tomcat8/src/main/java/org/jboss/modcluster/container/tomcat8/TomcatEngine.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2014, Red Hat Middleware LLC, and individual contributors
+ * Copyright 2017, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,26 +19,36 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-
 package org.jboss.modcluster.container.tomcat8;
 
-import static org.junit.Assert.assertSame;
-
-import org.jboss.modcluster.container.tomcat.TomcatServerFactory;
-import org.jboss.modcluster.container.tomcat.TomcatConnectorFactory;
+import org.apache.catalina.Engine;
+import org.jboss.modcluster.container.Context;
+import org.jboss.modcluster.container.Host;
+import org.jboss.modcluster.container.Server;
 import org.jboss.modcluster.container.tomcat.TomcatFactoryRegistry;
-import org.jboss.modcluster.container.tomcat.TomcatHostFactory;
 
 /**
- * @author Paul Ferraro
+ * @author Radoslav Husar
  */
-public class ServiceLoaderTomcatFactoryTestCase extends org.jboss.modcluster.container.tomcat.ServiceLoaderTomcatFactoryTestCase {
+public class TomcatEngine extends org.jboss.modcluster.container.tomcat.TomcatEngine {
+
+    public TomcatEngine(TomcatFactoryRegistry registry, Engine engine, Server server) {
+        super(registry, engine, server);
+    }
+
+    /**
+     * Propagates jvm-route configuration to contexts.
+     *
+     * @see <a href="https://issues.jboss.org/browse/MODCLUSTER-469">MODCLUSTER-469</a>
+     */
     @Override
-    protected void verifyCatalinaFactoryTypes(TomcatFactoryRegistry registry) {
-        assertSame(registry.getServerFactory().getClass(), TomcatServerFactory.class);
-        assertSame(registry.getEngineFactory().getClass(), TomcatEngineFactory.class);
-        assertSame(registry.getHostFactory().getClass(), TomcatHostFactory.class);
-        assertSame(registry.getContextFactory().getClass(), TomcatContextFactory.class);
-        assertSame(registry.getConnectorFactory().getClass(), TomcatConnectorFactory.class);
+    public void setJvmRoute(String jvmRoute) {
+        super.setJvmRoute(jvmRoute);
+
+        for (Host host : this.getHosts()) {
+            for (Context context : host.getContexts()) {
+                ((TomcatContext) context).setJvmRoute(jvmRoute);
+            }
+        }
     }
 }

--- a/container/tomcat8/src/main/java/org/jboss/modcluster/container/tomcat8/TomcatEngine.java
+++ b/container/tomcat8/src/main/java/org/jboss/modcluster/container/tomcat8/TomcatEngine.java
@@ -21,9 +21,12 @@
  */
 package org.jboss.modcluster.container.tomcat8;
 
+import org.apache.catalina.Container;
+import org.apache.catalina.Context;
 import org.apache.catalina.Engine;
-import org.jboss.modcluster.container.Context;
-import org.jboss.modcluster.container.Host;
+import org.apache.catalina.Host;
+import org.apache.catalina.Manager;
+import org.apache.catalina.SessionIdGenerator;
 import org.jboss.modcluster.container.Server;
 import org.jboss.modcluster.container.tomcat.TomcatFactoryRegistry;
 
@@ -45,9 +48,17 @@ public class TomcatEngine extends org.jboss.modcluster.container.tomcat.TomcatEn
     public void setJvmRoute(String jvmRoute) {
         super.setJvmRoute(jvmRoute);
 
-        for (Host host : this.getHosts()) {
-            for (Context context : host.getContexts()) {
-                ((TomcatContext) context).setJvmRoute(jvmRoute);
+        for (Container hostAsContainer : this.engine.findChildren()) {
+            Host host = (Host) hostAsContainer;
+            for (Container contextAsContainer : host.findChildren()) {
+                Context context = (Context) contextAsContainer;
+                Manager contextManager = context.getManager();
+                if (contextManager != null) {
+                    SessionIdGenerator sessionIdGenerator = contextManager.getSessionIdGenerator();
+                    if (sessionIdGenerator != null) {
+                        sessionIdGenerator.setJvmRoute(jvmRoute);
+                    }
+                }
             }
         }
     }

--- a/container/tomcat8/src/main/java/org/jboss/modcluster/container/tomcat8/TomcatEngineFactory.java
+++ b/container/tomcat8/src/main/java/org/jboss/modcluster/container/tomcat8/TomcatEngineFactory.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2014, Red Hat Middleware LLC, and individual contributors
+ * Copyright 2017, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,26 +19,19 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-
 package org.jboss.modcluster.container.tomcat8;
 
-import static org.junit.Assert.assertSame;
-
-import org.jboss.modcluster.container.tomcat.TomcatServerFactory;
-import org.jboss.modcluster.container.tomcat.TomcatConnectorFactory;
+import org.apache.catalina.Engine;
+import org.jboss.modcluster.container.Server;
+import org.jboss.modcluster.container.tomcat.EngineFactory;
 import org.jboss.modcluster.container.tomcat.TomcatFactoryRegistry;
-import org.jboss.modcluster.container.tomcat.TomcatHostFactory;
 
 /**
- * @author Paul Ferraro
+ * @author Radoslav Husar
  */
-public class ServiceLoaderTomcatFactoryTestCase extends org.jboss.modcluster.container.tomcat.ServiceLoaderTomcatFactoryTestCase {
+public class TomcatEngineFactory implements EngineFactory {
     @Override
-    protected void verifyCatalinaFactoryTypes(TomcatFactoryRegistry registry) {
-        assertSame(registry.getServerFactory().getClass(), TomcatServerFactory.class);
-        assertSame(registry.getEngineFactory().getClass(), TomcatEngineFactory.class);
-        assertSame(registry.getHostFactory().getClass(), TomcatHostFactory.class);
-        assertSame(registry.getContextFactory().getClass(), TomcatContextFactory.class);
-        assertSame(registry.getConnectorFactory().getClass(), TomcatConnectorFactory.class);
+    public org.jboss.modcluster.container.Engine createEngine(TomcatFactoryRegistry registry, Engine engine, Server server) {
+        return new TomcatEngine(registry, engine, server);
     }
 }

--- a/container/tomcat8/src/main/resources/META-INF/services/org.jboss.modcluster.container.tomcat.EngineFactory
+++ b/container/tomcat8/src/main/resources/META-INF/services/org.jboss.modcluster.container.tomcat.EngineFactory
@@ -1,0 +1,22 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2017, Red Hat, Inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+org.jboss.modcluster.container.tomcat8.TomcatEngineFactory

--- a/container/tomcat8/src/test/java/org/jboss/modcluster/container/tomcat8/EngineTestCase.java
+++ b/container/tomcat8/src/test/java/org/jboss/modcluster/container/tomcat8/EngineTestCase.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.modcluster.container.tomcat8;
+
+/**
+ * @author Radoslav Husar
+ */
+public class EngineTestCase extends org.jboss.modcluster.container.tomcat.EngineTestCase {
+}


### PR DESCRIPTION
…to JSESSIONID when generated by UUIDJvmRouteFactory; add org.jboss.modcluster.container.tomcat8.EngineTestCase

https://issues.jboss.org/browse/MODCLUSTER-469