### PR TITLE
MODCLUSTER-631 Maven pushes only one tomcat distribution archive on d…

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -73,9 +73,6 @@
                             <descriptors>
                                 <descriptor>src/assembly/demo.xml</descriptor>
                             </descriptors>
-                            <finalName>mod_cluster-demo-${project.version}</finalName>
-                            <recompressZippedFiles>true</recompressZippedFiles>
-                            <appendAssemblyId>false</appendAssemblyId>
                             <tarLongFileMode>gnu</tarLongFileMode>
                         </configuration>
                     </execution>
@@ -106,9 +103,6 @@
                                     <descriptors>
                                         <descriptor>src/assembly/tomcat7.xml</descriptor>
                                     </descriptors>
-                                    <finalName>mod_cluster-tomcat7-${project.version}</finalName>
-                                    <appendAssemblyId>false</appendAssemblyId>
-                                    <recompressZippedFiles>true</recompressZippedFiles>
                                     <tarLongFileMode>gnu</tarLongFileMode>
                                 </configuration>
                             </execution>
@@ -138,9 +132,6 @@
                                     <descriptors>
                                         <descriptor>src/assembly/tomcat8.xml</descriptor>
                                     </descriptors>
-                                    <finalName>mod_cluster-tomcat8-${project.version}</finalName>
-                                    <appendAssemblyId>false</appendAssemblyId>
-                                    <recompressZippedFiles>true</recompressZippedFiles>
                                     <tarLongFileMode>gnu</tarLongFileMode>
                                 </configuration>
                             </execution>
@@ -170,9 +161,6 @@
                                     <descriptors>
                                         <descriptor>src/assembly/tomcat85.xml</descriptor>
                                     </descriptors>
-                                    <finalName>mod_cluster-tomcat85-${project.version}</finalName>
-                                    <appendAssemblyId>false</appendAssemblyId>
-                                    <recompressZippedFiles>true</recompressZippedFiles>
                                     <tarLongFileMode>gnu</tarLongFileMode>
                                 </configuration>
                             </execution>
@@ -202,9 +190,6 @@
                                     <descriptors>
                                         <descriptor>src/assembly/tomcat9.xml</descriptor>
                                     </descriptors>
-                                    <finalName>mod_cluster-tomcat9-${project.version}</finalName>
-                                    <appendAssemblyId>false</appendAssemblyId>
-                                    <recompressZippedFiles>true</recompressZippedFiles>
                                     <tarLongFileMode>gnu</tarLongFileMode>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
…eploy

Jira
https://issues.jboss.org/browse/MODCLUSTER-631

So the best way to use this is to append assembly IDs (default) and attach automatically (default as well). This generates the following artefact names which is reasonable:
```
[rhusar@syrah 2.0.0.Alpha1-SNAPSHOT]$ ll -h
--
total 26904
-rw-r--r--  1 rhusar  staff   689B Nov 20 22:32 _remote.repositories
-rw-r--r--  1 rhusar  staff   2.7K Nov 20 22:33 maven-metadata-jboss-snapshots-repository.xml
-rw-r--r--  1 rhusar  staff    40B Nov 20 22:32 maven-metadata-jboss-snapshots-repository.xml.sha1
-rw-r--r--  1 rhusar  staff   2.2K Nov 20 22:32 maven-metadata-local.xml
-rw-r--r--  1 rhusar  staff   5.9M Nov 20 22:32 mod_cluster-distribution-2.0.0.Alpha1-SNAPSHOT-demo.tar.gz
-rw-r--r--  1 rhusar  staff   5.9M Nov 20 22:32 mod_cluster-distribution-2.0.0.Alpha1-SNAPSHOT-demo.zip
-rw-r--r--  1 rhusar  staff   227K Nov 20 22:32 mod_cluster-distribution-2.0.0.Alpha1-SNAPSHOT-tomcat7.tar.gz
-rw-r--r--  1 rhusar  staff   229K Nov 20 22:32 mod_cluster-distribution-2.0.0.Alpha1-SNAPSHOT-tomcat7.zip
-rw-r--r--  1 rhusar  staff   234K Nov 20 22:32 mod_cluster-distribution-2.0.0.Alpha1-SNAPSHOT-tomcat8.tar.gz
-rw-r--r--  1 rhusar  staff   236K Nov 20 22:32 mod_cluster-distribution-2.0.0.Alpha1-SNAPSHOT-tomcat8.zip
-rw-r--r--  1 rhusar  staff   237K Nov 20 22:32 mod_cluster-distribution-2.0.0.Alpha1-SNAPSHOT-tomcat85.tar.gz
-rw-r--r--  1 rhusar  staff   239K Nov 20 22:32 mod_cluster-distribution-2.0.0.Alpha1-SNAPSHOT-tomcat85.zip
-rw-r--r--  1 rhusar  staff   8.2K Nov 20 22:30 mod_cluster-distribution-2.0.0.Alpha1-SNAPSHOT.pom
-rw-r--r--  1 rhusar  staff   212B Nov 20 22:33 resolver-status.properties
```
thus

finalName = no need to override it to be pretty since its only affecting local build files 
appendAssemblyId = set to true, default, which generates a separate artefact for each zip/tar
recompressZippedFiles=is true by default, no need to override

