### PR TITLE
[1.3] MODCLUSTER-639 proxy reset requests can allow for other MCMPs to bad proxy

### DIFF
--- a/core/src/main/java/org/jboss/modcluster/mcmp/impl/DefaultMCMPHandler.java
+++ b/core/src/main/java/org/jboss/modcluster/mcmp/impl/DefaultMCMPHandler.java
@@ -382,7 +382,6 @@ public class DefaultMCMPHandler implements MCMPHandler {
                 if (proxy.getState() == Proxy.State.ERROR) {
 
                     proxy.closeConnection();
-                    proxy.setState(Proxy.State.OK);
 
                     String response = this.sendRequest(this.requestFactory.createInfoRequest(), proxy);
 
@@ -538,10 +537,10 @@ public class DefaultMCMPHandler implements MCMPHandler {
     }
 
     private String sendRequest(MCMPRequest request, Proxy proxy) {
-        // If there was an error, do nothing until the next periodic event, where the whole configuration
-        // will be refreshed
-        if (proxy.getState() != Proxy.State.OK)
+        // Never proceed with requests on a proxy in ERROR state unless the request type is INFO to return proxy back to OK state.
+        if (!(proxy.getState() == Proxy.State.OK || request.getRequestType() == MCMPRequestType.INFO)) {
             return null;
+        }
 
         log.tracef("Sending to %s: %s", proxy, request);
 
@@ -673,6 +672,8 @@ public class DefaultMCMPHandler implements MCMPHandler {
                 // Mark as error if the front end server did not return 200; the configuration will
                 // be refreshed during the next periodic event
                 if (status == 200) {
+                    proxy.setState(State.OK);
+
                     if (request.getRequestType().getEstablishesServer()) {
                         // We know the request succeeded, so if appropriate
                         // mark the proxy as established before any possible

--- a/core/src/main/java/org/jboss/modcluster/mcmp/impl/DefaultMCMPHandler.java
+++ b/core/src/main/java/org/jboss/modcluster/mcmp/impl/DefaultMCMPHandler.java
@@ -603,7 +603,7 @@ public class DefaultMCMPHandler implements MCMPHandler {
                 String host = proxy.getSocketAddress().getHostName();
                 String proxyhead;
 
-                if(host != null && host.contains(":")) {
+                if (host != null && host.contains(":")) {
                     proxyhead = head + "[" + host + "]:" + proxy.getSocketAddress().getPort();
                 } else {
                     proxyhead = head + host + ":" + proxy.getSocketAddress().getPort();
@@ -629,7 +629,7 @@ public class DefaultMCMPHandler implements MCMPHandler {
                 String errorType = null;
                 int contentLength = 0;
                 boolean close = false;
-                boolean chuncked = false;
+                boolean chunked = false;
                 if (line != null) {
                     try {
                         int spaceIndex = line.indexOf(' ');
@@ -637,8 +637,9 @@ public class DefaultMCMPHandler implements MCMPHandler {
                         /* Ignore everything until we have a HTTP headers */
                         while (spaceIndex == -1) {
                             line = reader.readLine();
-                            if (line == null)
+                            if (line == null) {
                                 return null; // Connection closed...
+                            }
                             spaceIndex = line.indexOf(' ');
                         }
                         String responseStatus = line.substring(spaceIndex + 1, line.indexOf(' ', spaceIndex + 1));
@@ -660,7 +661,7 @@ public class DefaultMCMPHandler implements MCMPHandler {
                                 close = "close".equalsIgnoreCase(headerValue);
                             } else if ("Transfer-Encoding".equalsIgnoreCase(headerName)) {
                                 if ("chunked".equalsIgnoreCase(headerValue))
-                                    chuncked = true;
+                                    chunked = true;
                             }
                             line = reader.readLine();
                         }
@@ -691,7 +692,7 @@ public class DefaultMCMPHandler implements MCMPHandler {
 
                 if (close) {
                     contentLength = Integer.MAX_VALUE;
-                } else if (contentLength == 0 && ! chuncked) {
+                } else if (contentLength == 0 && ! chunked) {
                     return null;
                 }
 
@@ -699,23 +700,25 @@ public class DefaultMCMPHandler implements MCMPHandler {
                 StringBuilder result = new StringBuilder();
                 char[] buffer = new char[512];
 
-                if (chuncked) {
+                if (chunked) {
                     boolean skipcrlf = false;
                     for (;;) {
-                         if (skipcrlf)
+                        if (skipcrlf) {
                             reader.readLine(); // Skip CRLF
-                         else
-                             skipcrlf = true;
+                        } else {
+                            skipcrlf = true;
+                        }
                         line = reader.readLine();
                         contentLength = Integer.parseInt(line, 16);
                         if (contentLength == 0) {
-                                        reader.readLine(); // Skip last CRLF.
+                            reader.readLine(); // Skip last CRLF.
                             break;
-                                }
+                        }
                         while (contentLength > 0) {
                             int bytes = reader.read(buffer, 0, (contentLength > buffer.length) ? buffer.length : contentLength);
-                            if (bytes <= 0)
+                            if (bytes <= 0) {
                                 break;
+                            }
                             result.append(buffer, 0, bytes);
                             contentLength -= bytes;
                         }
@@ -723,10 +726,9 @@ public class DefaultMCMPHandler implements MCMPHandler {
                 } else {
                     while (contentLength > 0) {
                         int bytes = reader.read(buffer, 0, (contentLength > buffer.length) ? buffer.length : contentLength);
-
-                        if (bytes <= 0)
+                        if (bytes <= 0) {
                             break;
-
+                        }
                         result.append(buffer, 0, bytes);
                         contentLength -= bytes;
                     }


### PR DESCRIPTION
Jira
https://issues.jboss.org/browse/MODCLUSTER-639

Here are some steps to simulate a bad proxy:

1. Configure mod_cluster to use good and bad proxy
```
/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=proxy1:add(host=127.0.0.1,port=9090
/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=proxy2:add(host=127.0.0.1,port=9190
/subsystem=modcluster/mod-cluster-config=configuration/:write-attribute(name=proxies, value=[proxy1, proxy2]
```
2. Start a fake bad proxy with a python script
```
import socket
import sys
s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
try:
    s.bind(('localhost', 9190))
except socket.error as e:
    sys.exit()
s.listen(5)
while 1:
    conn, addr = s.accept()
    print 'Connection ' + addr[0] + ':' + str(addr[1])
```