### PR TITLE
MODCLUSTER-649 Support JDK11 build build 11-ea+3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,34 @@
+sudo: false
+dist: trusty
 language: java
-jdk:
-  - oraclejdk9
-  - oraclejdk8
-  - openjdk7
-script: mvn verify -Pdist
+script: mvn verify -Pdist && mvn verify -PTC9 -Pdist
 matrix:
   include:
-  # Workaround travis dropping oraclejdk7 on stable/trusty
-  # https://github.com/travis-ci/travis-ci/issues/7884#issuecomment-308451879
-  - jdk: oraclejdk7
-    dist: precise
-  # Tomcat 9.x targets
-  - jdk: oraclejdk9
-    script: mvn verify -PTC9 -Pdist
-  - jdk: oraclejdk8
-    script: mvn verify -PTC9 -Pdist
-notifications:
-  email: false
-# Workaround openjdk7 crashes in container-based environments failing with:
-# *** buffer overflow detected ***: /usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java terminated
-# /usr/lib/jvm/java-7-openjdk-amd64/jre/lib/amd64/libnet.so(Java_java_net_Inet4AddressImpl_getLocalHostName+0x190)[0x7fde947f34a0]
-sudo: required
-addons:
-  hostname: localhost
+    # JDK 7
+    - env: JDK_RELEASE='OracleJDK 7'
+      jdk: oraclejdk7
+      dist: precise
+      script: mvn verify -Pdist
+    - env: JDK_RELEASE='OpenJDK 7'
+      jdk: openjdk7
+      script: mvn verify -Pdist
+    # JDK 8
+    - env: JDK_RELEASE='OracleJDK 8'
+      jdk: oraclejdk8
+    - env: JDK_RELEASE='OpenJDK 8'
+      jdk: openjdk8
+    # JDK 9
+    - env: JDK_RELEASE='OracleJDK 9'
+      jdk: oraclejdk9
+    - env: JDK_RELEASE='OpenJDK 9'
+      install: . ./install-jdk.sh -F 9
+    # JDK 10-ea
+    - env: JDK_RELEASE='OracleJDK 10'
+      install: . ./install-jdk.sh -F 10 -L BCL
+    - env: JDK_RELEASE='OpenJDK 10'
+      install: . ./install-jdk.sh -F 10 -L GPL
+    # JDK 11-ea
+    - env: JDK_RELEASE='OracleJDK 11'
+      install: . ./install-jdk.sh -F 11 -L BCL
+    - env: JDK_RELEASE='OpenJDK 11'
+      install: . ./install-jdk.sh -F 11 -L GPL

--- a/install-jdk.sh
+++ b/install-jdk.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+
+#
+# Install JDK for Linux
+#
+# This script determines the most recent early-access build number,
+# downloads the JDK archive to the user home directory and extracts
+# it there.
+#
+# Example usage
+#
+#   install-jdk.sh                 | install most recent (early-access) JDK
+#   install-jdk.sh -W /usr/opt     | install most recent (early-access) JDK to /usr/opt
+#   install-jdk.sh -F 9            | install most recent OpenJDK 9
+#   install-jdk.sh -F 10           | install most recent OpenJDK 10
+#   install-jdk.sh -F 10 -L BCL    | install most recent Oracle JDK 10
+#   install-jdk.sh -F 11           | install most recent OpenJDK 11
+#   install-jdk.sh -F 11 -L BCL    | install most recent Oracle JDK 11
+#
+# Options
+#
+#   -F f | Feature number of the JDK release  [9|10|...]
+#   -B b | Build number of the JDK release    [?|1|2...]
+#   -L l | License of the JDK                 [GPL|BCL]
+#   -W w | Working directory and install path [${HOME}]
+#
+# Exported environment variables
+#
+#   JAVA_HOME is set to the extracted JDK directory
+#   PATH is prepended with ${JAVA_HOME}/bin
+#
+# (C) 2018 Christian Stein
+#
+# https://github.com/sormuras/bach/blob/master/install-jdk.sh
+#
+set -e
+
+JDK_FEATURE='11'
+JDK_BUILD='?'
+JDK_LICENSE='GPL'
+JDK_WORKSPACE=${HOME}
+
+while getopts F:B:L:W: option
+do
+  case "${option}" in
+    F) JDK_FEATURE=${OPTARG};;
+    B) JDK_BUILD=${OPTARG};;
+    L) JDK_LICENSE=${OPTARG};;
+    W) JDK_WORKSPACE=${OPTARG};;
+ esac
+done
+
+#
+# Other constants
+#
+JDK_DOWNLOAD='https://download.java.net/java'
+JDK_BASENAME='openjdk'
+if [ "${JDK_LICENSE}" != 'GPL' ]; then
+  JDK_BASENAME='jdk'
+fi
+
+#
+# 9
+#
+if [ "${JDK_FEATURE}" == '9' ]; then
+  if [ "${JDK_BUILD}" == '?' ]; then
+    TMP=$(curl -L jdk.java.net/${JDK_FEATURE})
+    TMP="${TMP#*<h1>JDK}"                                   # remove everything before the number
+    TMP="${TMP%%General-Availability Release*}"             # remove everything after the number
+    JDK_BUILD="$(echo -e "${TMP}" | tr -d '[:space:]')"     # remove all whitespace
+  fi
+
+  JDK_ARCHIVE=${JDK_BASENAME}-${JDK_BUILD}_linux-x64_bin.tar.gz
+  JDK_URL=${JDK_DOWNLOAD}/GA/jdk${JDK_FEATURE}/${JDK_BUILD}/binaries/${JDK_ARCHIVE}
+  JDK_HOME=jdk-${JDK_BUILD}
+fi
+
+#
+# 10
+#
+if [ "${JDK_FEATURE}" == '10' ]; then
+  if [ "${JDK_BUILD}" == '?' ]; then
+    TMP=$(curl -L jdk.java.net/${JDK_FEATURE})
+    TMP="${TMP#*Most recent build: jdk-${JDK_FEATURE}+}"    # remove everything before the number
+    TMP="${TMP%%<*}"                                        # remove everything after the number
+    JDK_BUILD="$(echo -e "${TMP}" | tr -d '[:space:]')"     # remove all whitespace
+  fi
+
+  JDK_ARCHIVE=${JDK_BASENAME}-${JDK_FEATURE}+${JDK_BUILD}_linux-x64_bin.tar.gz
+  JDK_URL=${JDK_DOWNLOAD}/jdk${JDK_FEATURE}/archive/${JDK_BUILD}/${JDK_LICENSE}/${JDK_ARCHIVE}
+  JDK_HOME=jdk-${JDK_FEATURE}
+fi
+
+#
+# 11
+#
+if [ "${JDK_FEATURE}" == '11' ]; then
+  if [ "${JDK_BUILD}" == '?' ]; then
+    TMP=$(curl -L jdk.java.net/${JDK_FEATURE})
+    TMP="${TMP#*Most recent build: jdk-${JDK_FEATURE}-ea+}" # remove everything before the number
+    TMP="${TMP%%<*}"                                        # remove everything after the number
+    JDK_BUILD="$(echo -e "${TMP}" | tr -d '[:space:]')"     # remove all whitespace
+  fi
+
+  JDK_ARCHIVE=${JDK_BASENAME}-${JDK_FEATURE}-ea+${JDK_BUILD}_linux-x64_bin.tar.gz
+  JDK_URL=${JDK_DOWNLOAD}/early_access/jdk${JDK_FEATURE}/${JDK_BUILD}/${JDK_LICENSE}/${JDK_ARCHIVE}
+  JDK_HOME=jdk-${JDK_FEATURE}
+fi
+
+#
+# Create any missing intermediate paths, switch to workspace, download, unpack, switch back.
+#
+mkdir -p ${JDK_WORKSPACE}
+cd ${JDK_WORKSPACE}
+wget ${JDK_URL}
+tar -xzf ${JDK_ARCHIVE}
+cd -
+
+#
+# Update environment and test-drive.
+#
+export JAVA_HOME=${JDK_WORKSPACE}/${JDK_HOME}
+export PATH=${JAVA_HOME}/bin:$PATH
+
+java --version

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>25</version>
+        <version>26</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -84,8 +84,6 @@
         <!-- Plugin versions -->
         <version.checkstyle>6.19</version.checkstyle>
         <version.org.wildfly.checkstyle-config>1.0.6.Final</version.org.wildfly.checkstyle-config>
-        <!-- Downgrade surefire plugin from 2.20.1 to 2.19.1 which works with JDK10 -->
-        <version.surefire.plugin>2.19.1</version.surefire.plugin>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,14 @@
         </repository>
     </repositories>
 
+    <modules>
+        <module>core</module>
+        <module>container</module>
+        <module>load-spi</module>
+        <module>demo</module>
+        <module>dist</module>
+    </modules>
+
     <properties>
         <!-- Override default 1.8 target/source in jboss-parent -->
         <maven.compiler.target>1.7</maven.compiler.target>
@@ -60,7 +68,8 @@
 
         <!-- Dependency versions -->
         <version.jboss-logging>3.3.1.Final</version.jboss-logging>
-        <version.jboss-logging-processor>2.0.2.Final</version.jboss-logging-processor>
+        <version.jboss-logging-processor>2.1.0.Final</version.jboss-logging-processor>
+        <version.jboss-logging-processor.jdk7>2.0.2.Final</version.jboss-logging-processor.jdk7>
         <version.tomcat7>7.0.84</version.tomcat7>
         <version.tomcat8>8.0.49</version.tomcat8>
         <version.tomcat85>8.5.27</version.tomcat85>
@@ -275,49 +284,6 @@
 
     <profiles>
         <profile>
-            <id>default</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <modules>
-                <module>core</module>
-                <module>container</module>
-                <module>load-spi</module>
-                <module>demo</module>
-                <module>dist</module>
-            </modules>
-        </profile>
-        <profile>
-            <id>jdk9</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <modules>
-                <module>core</module>
-                <module>container</module>
-                <module>load-spi</module>
-                <module>demo</module>
-                <module>dist</module>
-            </modules>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <version>${version.compiler.plugin}</version>
-                        <configuration>
-                            <!-- Fork is needed so compiler args can be used -->
-                            <fork>true</fork>
-                            <compilerArgs>
-                                <arg>-J--add-modules</arg>
-                                <arg>-Jjava.xml.ws.annotation</arg>
-                            </compilerArgs>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>TC7</id>
             <modules>
                 <module>core</module>
@@ -363,6 +329,15 @@
                 <module>dist</module>
                 <module>docs</module>
             </modules>
+        </profile>
+        <profile>
+            <id>jdk7</id>
+            <activation>
+                <jdk>1.7</jdk>
+            </activation>
+            <properties>
+                <version.jboss-logging-processor>${version.jboss-logging-processor.jdk7}</version.jboss-logging-processor>
+            </properties>
         </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <maven.compiler.source>1.7</maven.compiler.source>
 
         <!-- Dependency versions -->
-        <version.jboss-logging>3.3.1.Final</version.jboss-logging>
+        <version.jboss-logging>3.3.2.Final</version.jboss-logging>
         <version.jboss-logging-processor>2.1.0.Final</version.jboss-logging-processor>
         <version.jboss-logging-processor.jdk7>2.0.2.Final</version.jboss-logging-processor.jdk7>
         <version.tomcat7>7.0.84</version.tomcat7>


### PR DESCRIPTION
Jira
https://issues.jboss.org/browse/MODCLUSTER-649

https://issues.jboss.org/browse/MODCLUSTER-647 Upgrade jboss-logging-processor to 2.1.0.Final
https://issues.jboss.org/browse/MODCLUSTER-648 Upgrade jboss-logging to 3.3.2.Final
https://issues.jboss.org/browse/MODCLUSTER-651 Upgrade jboss-parent to 26
https://issues.jboss.org/browse/MODCLUSTER-650 Travis CI: Expand build matrix to JDK10 and JDK11