### PR TITLE
Removed HP-UX from the list of platforms.

### DIFF
--- a/docs/src/main/asciidoc/introduction.adoc
+++ b/docs/src/main/asciidoc/introduction.adoc
@@ -30,7 +30,6 @@ platforms:
 * Linux x86, x64, ia64
 * Solaris x86, SPARC
 * Windows x86, x64, ia64
-* HP-UX PA-RISC, ia64
 
 [[advantages]]
 == Advantages


### PR DESCRIPTION
HP-UX is no longer being built.