### PR TITLE
[1.4] MODCLUSTER-653 DefaultMCMPHandler should close a connection when rece…

### DIFF
--- a/core/src/main/java/org/jboss/modcluster/mcmp/impl/DefaultMCMPHandler.java
+++ b/core/src/main/java/org/jboss/modcluster/mcmp/impl/DefaultMCMPHandler.java
@@ -679,6 +679,10 @@ public class DefaultMCMPHandler implements MCMPHandler {
                     proxy.setIoExceptionLogged(false);
                 }
 
+                if (close) {
+                    proxy.closeConnection();
+                }
+
                 return result.toString();
             } catch (IOException e) {
                 // Most likely this is a connection error with the proxy


### PR DESCRIPTION
…iving "Connection: close" header

https://issues.jboss.org/browse/MODCLUSTER-653