### PR TITLE
MODCLUSTER-656 Remove *-javadoc.jar from distribution profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,15 @@
+# Maven
+target/
+
+# Eclipse IDE
 .settings
 .classpath
 .project
-bin
-target
 
-.idea
+# IntelliJ IDEA IDE
+.idea/
 *.ipr
 *.iml
+
+# macOS
+.DS_Store

--- a/dist/src/assembly/demo.xml
+++ b/dist/src/assembly/demo.xml
@@ -40,6 +40,7 @@
                 <include>*.jar</include>
             </includes>
             <excludes>
+                <exclude>*-javadoc.jar</exclude>
                 <exclude>*-sources.jar</exclude>
                 <exclude>*-tests.jar</exclude>
             </excludes>

--- a/dist/src/assembly/tomcat-component.xml
+++ b/dist/src/assembly/tomcat-component.xml
@@ -30,6 +30,7 @@
                 <include>*.jar</include>
             </includes>
             <excludes>
+                <exclude>*-javadoc.jar</exclude>
                 <exclude>*-sources.jar</exclude>
                 <exclude>*-tests.jar</exclude>
             </excludes>
@@ -41,6 +42,7 @@
                 <include>*.jar</include>
             </includes>
             <excludes>
+                <exclude>*-javadoc.jar</exclude>
                 <exclude>*-sources.jar</exclude>
                 <exclude>*-tests.jar</exclude>
             </excludes>
@@ -52,6 +54,7 @@
                 <include>*.jar</include>
             </includes>
             <excludes>
+                <exclude>*-javadoc.jar</exclude>
                 <exclude>*-sources.jar</exclude>
                 <exclude>*-tests.jar</exclude>
             </excludes>
@@ -63,6 +66,7 @@
                 <include>*.jar</include>
             </includes>
             <excludes>
+                <exclude>*-javadoc.jar</exclude>
                 <exclude>*-sources.jar</exclude>
                 <exclude>*-tests.jar</exclude>
             </excludes>

--- a/dist/src/assembly/tomcat8.xml
+++ b/dist/src/assembly/tomcat8.xml
@@ -38,6 +38,7 @@
                 <include>*.jar</include>
             </includes>
             <excludes>
+                <exclude>*-javadoc.jar</exclude>
                 <exclude>*-sources.jar</exclude>
                 <exclude>*-tests.jar</exclude>
             </excludes>

--- a/dist/src/assembly/tomcat85.xml
+++ b/dist/src/assembly/tomcat85.xml
@@ -38,6 +38,7 @@
                 <include>*.jar</include>
             </includes>
             <excludes>
+                <exclude>*-javadoc.jar</exclude>
                 <exclude>*-sources.jar</exclude>
                 <exclude>*-tests.jar</exclude>
             </excludes>

--- a/dist/src/assembly/tomcat9.xml
+++ b/dist/src/assembly/tomcat9.xml
@@ -38,6 +38,7 @@
                 <include>*.jar</include>
             </includes>
             <excludes>
+                <exclude>*-javadoc.jar</exclude>
                 <exclude>*-sources.jar</exclude>
                 <exclude>*-tests.jar</exclude>
             </excludes>

--- a/install-jdk.sh
+++ b/install-jdk.sh
@@ -23,7 +23,7 @@ set -o errexit
 
 function initialize() {
     readonly script_name="$(basename "${BASH_SOURCE[0]}")"
-    readonly script_version='2018-04-17'
+    readonly script_version='2018-04-30'
 
     dry=false
     silent=false
@@ -139,7 +139,6 @@ function parse_options() {
             -c|-C|--cacerts)
                 cacerts=true
                 verbose "Linking system CA certificates"
-                shift
                 ;;
             *)
                 script_exit "Invalid argument was provided: ${option}" 2


### PR DESCRIPTION
Jira
https://issues.jboss.org/browse/MODCLUSTER-656