### PR TITLE
[1.4] MODCLUSTER-656 Remove *-javadoc.jar from distribution profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,15 @@
+# Maven
+target/
+
+# Eclipse IDE
 .settings
 .classpath
 .project
-bin
-target
 
-.idea
+# IntelliJ IDEA IDE
+.idea/
 *.ipr
 *.iml
+
+# macOS
+.DS_Store

--- a/dist/src/assembly/demo.xml
+++ b/dist/src/assembly/demo.xml
@@ -40,6 +40,7 @@
                 <include>*.jar</include>
             </includes>
             <excludes>
+                <exclude>*-javadoc.jar</exclude>
                 <exclude>*-sources.jar</exclude>
                 <exclude>*-tests.jar</exclude>
             </excludes>

--- a/dist/src/assembly/tomcat-component.xml
+++ b/dist/src/assembly/tomcat-component.xml
@@ -30,6 +30,7 @@
                 <include>*.jar</include>
             </includes>
             <excludes>
+                <exclude>*-javadoc.jar</exclude>
                 <exclude>*-sources.jar</exclude>
                 <exclude>*-tests.jar</exclude>
             </excludes>
@@ -41,6 +42,7 @@
                 <include>*.jar</include>
             </includes>
             <excludes>
+                <exclude>*-javadoc.jar</exclude>
                 <exclude>*-sources.jar</exclude>
                 <exclude>*-tests.jar</exclude>
             </excludes>
@@ -52,6 +54,7 @@
                 <include>*.jar</include>
             </includes>
             <excludes>
+                <exclude>*-javadoc.jar</exclude>
                 <exclude>*-sources.jar</exclude>
                 <exclude>*-tests.jar</exclude>
             </excludes>
@@ -63,6 +66,7 @@
                 <include>*.jar</include>
             </includes>
             <excludes>
+                <exclude>*-javadoc.jar</exclude>
                 <exclude>*-sources.jar</exclude>
                 <exclude>*-tests.jar</exclude>
             </excludes>

--- a/dist/src/assembly/tomcat8.xml
+++ b/dist/src/assembly/tomcat8.xml
@@ -38,6 +38,7 @@
                 <include>*.jar</include>
             </includes>
             <excludes>
+                <exclude>*-javadoc.jar</exclude>
                 <exclude>*-sources.jar</exclude>
                 <exclude>*-tests.jar</exclude>
             </excludes>

--- a/dist/src/assembly/tomcat85.xml
+++ b/dist/src/assembly/tomcat85.xml
@@ -38,6 +38,7 @@
                 <include>*.jar</include>
             </includes>
             <excludes>
+                <exclude>*-javadoc.jar</exclude>
                 <exclude>*-sources.jar</exclude>
                 <exclude>*-tests.jar</exclude>
             </excludes>

--- a/dist/src/assembly/tomcat9.xml
+++ b/dist/src/assembly/tomcat9.xml
@@ -38,6 +38,7 @@
                 <include>*.jar</include>
             </includes>
             <excludes>
+                <exclude>*-javadoc.jar</exclude>
                 <exclude>*-sources.jar</exclude>
                 <exclude>*-tests.jar</exclude>
             </excludes>


### PR DESCRIPTION
master
https://github.com/modcluster/mod_cluster/pull/331

Jira
https://issues.jboss.org/browse/MODCLUSTER-656