### PR TITLE
Travis CI: Make OracleJDK 7 build use TLSv1.2 to be able to download …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,11 @@ matrix:
   include:
   # Workaround travis dropping oraclejdk7 on stable/trusty
   # https://github.com/travis-ci/travis-ci/issues/7884#issuecomment-308451879
-  - jdk: oraclejdk7
+  - env: JDK_RELEASE='OracleJDK 7'
+    jdk: oraclejdk7
     dist: precise
+    install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dhttps.protocols=TLSv1.2
+    script: mvn verify -Pdist -Dhttps.protocols=TLSv1.2
   # Tomcat 9.x targets
   - jdk: oraclejdk9
     script: mvn verify -PTC9 -Pdist


### PR DESCRIPTION
…artefacts from Maven Central