### PR TITLE
MODCLUSTER-663 mod_cluster reports "Starting to drain 1 active sessio…

### DIFF
--- a/core/src/main/java/org/jboss/modcluster/ModClusterLogger.java
+++ b/core/src/main/java/org/jboss/modcluster/ModClusterLogger.java
@@ -194,4 +194,8 @@ public interface ModClusterLogger {
 
     @Message(id = 53, value = "Attempted to create multicast socket with unicast address (%s)! Disabling multicast advertise mechanism.")
     RuntimeException createMulticastSocketWithUnicastAddress(InetAddress address);
+
+    @LogMessage(level = INFO)
+    @Message(id = 54, value = "Starting to drain %d active sessions from %s:%s waiting indefinitely until all remaining sessions are drained or expired.")
+    void startSessionDrainingIndefinitely(int sessions, Host host, Context context);
 }

--- a/core/src/main/java/org/jboss/modcluster/ModClusterService.java
+++ b/core/src/main/java/org/jboss/modcluster/ModClusterService.java
@@ -684,10 +684,14 @@ public class ModClusterService implements ModClusterServiceMBean, ContainerEvent
         if (remainingSessions == 0)
             return true;
 
-        // Notify the user that the server is draining sessions since it might appear stuck since messages while draining are on DEBUG
-        ModClusterLogger.LOGGER.startSessionDraining(remainingSessions, context.getHost(), context, TimeUnit.MILLISECONDS.toSeconds(end - start));
-
         boolean noTimeout = (start >= end);
+
+        // Notify the user that the server is draining sessions since it might appear stuck since messages while draining are on DEBUG
+        if (noTimeout) {
+            ModClusterLogger.LOGGER.startSessionDrainingIndefinitely(remainingSessions, context.getHost(), context);
+        } else {
+            ModClusterLogger.LOGGER.startSessionDraining(remainingSessions, context.getHost(), context, TimeUnit.MILLISECONDS.toSeconds(end - start));
+        }
 
         HttpSessionListener listener = new NotifyOnDestroySessionListener();
 


### PR DESCRIPTION
…ns from (...) in 0 seconds." even when it waits indefinitely

https://issues.jboss.org/browse/MODCLUSTER-663