### PR TITLE
[1.4] MODCLUSTER-691 Upgrade jboss-logging to 3.4.0.Final + MODCLUSTER-692 Upgrade jboss-logging-processor to 2.2.0.Final 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <properties>
         <!-- Dependency versions -->
         <version.jboss-logging>3.4.0.Final</version.jboss-logging>
-        <version.jboss-logging-processor>2.0.2.Final</version.jboss-logging-processor>
+        <version.jboss-logging-processor>2.2.0.Final</version.jboss-logging-processor>
         <version.tomcat7>7.0.79</version.tomcat7>
         <version.tomcat8>8.0.45</version.tomcat8>
         <version.tomcat85>8.5.20</version.tomcat85>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
     <properties>
         <!-- Dependency versions -->
-        <version.jboss-logging>3.3.1.Final</version.jboss-logging>
+        <version.jboss-logging>3.4.0.Final</version.jboss-logging>
         <version.jboss-logging-processor>2.0.2.Final</version.jboss-logging-processor>
         <version.tomcat7>7.0.79</version.tomcat7>
         <version.tomcat8>8.0.45</version.tomcat8>


### PR DESCRIPTION
https://issues.jboss.org/browse/MODCLUSTER-691
https://issues.jboss.org/browse/MODCLUSTER-692