### PR TITLE
Upgrade Tomcat to 7.0.103, 8.5.53, and 9.0.33

### DIFF
--- a/container/tomcat/src/test/java/org/jboss/modcluster/container/tomcat/ConnectorTestCase.java
+++ b/container/tomcat/src/test/java/org/jboss/modcluster/container/tomcat/ConnectorTestCase.java
@@ -29,6 +29,10 @@ import org.jboss.modcluster.container.Connector;
 import org.junit.Assert;
 import org.junit.Test;
 
+/**
+ * @author Radoslav Husar
+ * @author Paul Ferraro
+ */
 public class ConnectorTestCase {
     protected final Connector ajpConnector = createConnector("AJP/1.3", Connector.Type.AJP, false);
     protected final Connector httpConnector = createConnector("HTTP/1.1", Connector.Type.HTTP, false);
@@ -81,7 +85,10 @@ public class ConnectorTestCase {
     @Test
     public void setAddress() throws UnknownHostException {
         String address = "127.0.0.1";
-        Assert.assertNull(this.ajpConnector.getAddress());
+
+        // Since 7.0.100, 8.5.51, 9.0.31, and 10.0.0-M3 the default bind address for the AJP/1.3 connector is the loopback address
+        Assert.assertEquals(InetAddress.getLoopbackAddress(), this.ajpConnector.getAddress());
+
         this.ajpConnector.setAddress(InetAddress.getByName(address));
         Assert.assertEquals(address, this.ajpConnector.getAddress().getHostAddress());
 

--- a/container/tomcat100/src/test/java/org/jboss/modcluster/container/tomcat100/ConnectorTestCase.java
+++ b/container/tomcat100/src/test/java/org/jboss/modcluster/container/tomcat100/ConnectorTestCase.java
@@ -21,20 +21,8 @@
  */
 package org.jboss.modcluster.container.tomcat100;
 
-import java.net.UnknownHostException;
-
-import org.junit.Ignore;
-import org.junit.Test;
-
 /**
  * @author Radoslav Husar
  */
 public class ConnectorTestCase extends org.jboss.modcluster.container.tomcat.ConnectorTestCase {
-
-    @Ignore
-    @Override
-    @Test
-    public void setAddress() throws UnknownHostException {
-        super.setAddress();
-    }
 }

--- a/container/tomcat8/src/test/java/org/jboss/modcluster/container/tomcat8/ConnectorTestCase.java
+++ b/container/tomcat8/src/test/java/org/jboss/modcluster/container/tomcat8/ConnectorTestCase.java
@@ -21,8 +21,35 @@
  */
 package org.jboss.modcluster.container.tomcat8;
 
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
 /**
  * @author Paul Ferraro
+ * @author Radoslav Husar
  */
 public class ConnectorTestCase extends org.jboss.modcluster.container.tomcat.ConnectorTestCase {
+
+    @Test
+    public void setAddress() throws UnknownHostException {
+        String address = "127.0.0.1";
+
+        // Since 7.0.100, 8.5.51, 9.0.31, and 10.0.0-M3 the default bind address for the AJP/1.3 connector is the loopback address
+        // -> however 8.0.x has not been updated yet
+        Assert.assertNull(this.ajpConnector.getAddress());
+
+        this.ajpConnector.setAddress(InetAddress.getByName(address));
+        Assert.assertEquals(address, this.ajpConnector.getAddress().getHostAddress());
+
+        Assert.assertNull(this.httpConnector.getAddress());
+        this.httpConnector.setAddress(InetAddress.getByName(address));
+        Assert.assertEquals(address, this.httpConnector.getAddress().getHostAddress());
+
+        Assert.assertNull(this.httpsConnector.getAddress());
+        this.httpsConnector.setAddress(InetAddress.getByName(address));
+        Assert.assertEquals(address, this.httpsConnector.getAddress().getHostAddress());
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -64,10 +64,10 @@
         <!-- Dependency versions -->
         <version.jboss-logging>3.4.1.Final</version.jboss-logging>
         <version.jboss-logging-processor>2.2.1.Final</version.jboss-logging-processor>
-        <version.tomcat7>7.0.99</version.tomcat7>
+        <version.tomcat7>7.0.103</version.tomcat7>
         <version.tomcat8>8.0.53</version.tomcat8>
-        <version.tomcat85>8.5.47</version.tomcat85>
-        <version.tomcat9>9.0.30</version.tomcat9>
+        <version.tomcat85>8.5.53</version.tomcat85>
+        <version.tomcat9>9.0.33</version.tomcat9>
         <version.tomcat100>10.0.0-M3</version.tomcat100>
         <version.http-client>4.5.12</version.http-client>
         <version.jfreechart>1.0.13</version.jfreechart>


### PR DESCRIPTION
* update tests because since 7.0.100, 8.5.51, 9.0.31, and 10.0.0-M3 the default bind address for the AJP/1.3 connector is the loopback address