### PR TITLE
MODCLUSTER-720 Allow mod_cluster listener to register at <Service> le…

### DIFF
--- a/container/tomcat/src/main/java/org/jboss/modcluster/container/tomcat/ServiceFilteringDelegatingServer.java
+++ b/container/tomcat/src/main/java/org/jboss/modcluster/container/tomcat/ServiceFilteringDelegatingServer.java
@@ -1,0 +1,217 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.modcluster.container.tomcat;
+
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.LifecycleListener;
+import org.apache.catalina.LifecycleState;
+import org.apache.catalina.Server;
+import org.apache.catalina.Service;
+import org.apache.catalina.deploy.NamingResources;
+import org.apache.catalina.startup.Catalina;
+
+import javax.naming.Context;
+import java.util.Objects;
+
+/**
+ * A {@link Server} delegate which filters found services to return only one configured {@link Service}.
+ *
+ * @author Radoslav Husar
+ */
+public class ServiceFilteringDelegatingServer implements Server {
+
+    private final Server delegate;
+    private final String serviceName;
+
+    public ServiceFilteringDelegatingServer(Service service) {
+        super();
+        this.delegate = service.getServer();
+        this.serviceName = service.getName();
+    }
+
+    @Override
+    public Service[] findServices() {
+        for (Service service : delegate.findServices()) {
+            if (service.getName().equals(serviceName)) {
+                return new Service[] { service };
+            }
+        }
+
+        return new Service[] {};
+    }
+
+    // Delegating methods
+
+    @Override
+    public String getInfo() {
+        return delegate.getInfo();
+    }
+
+    @Override
+    public NamingResources getGlobalNamingResources() {
+        return delegate.getGlobalNamingResources();
+    }
+
+    @Override
+    public void setGlobalNamingResources(NamingResources globalNamingResources) {
+        delegate.setGlobalNamingResources(globalNamingResources);
+    }
+
+    @Override
+    public Context getGlobalNamingContext() {
+        return delegate.getGlobalNamingContext();
+    }
+
+    @Override
+    public int getPort() {
+        return delegate.getPort();
+    }
+
+    @Override
+    public void setPort(int port) {
+        delegate.setPort(port);
+    }
+
+    @Override
+    public String getAddress() {
+        return delegate.getAddress();
+    }
+
+    @Override
+    public void setAddress(String address) {
+        delegate.setAddress(address);
+    }
+
+    @Override
+    public String getShutdown() {
+        return delegate.getShutdown();
+    }
+
+    @Override
+    public void setShutdown(String shutdown) {
+        delegate.setShutdown(shutdown);
+    }
+
+    @Override
+    public ClassLoader getParentClassLoader() {
+        return delegate.getParentClassLoader();
+    }
+
+    @Override
+    public void setParentClassLoader(ClassLoader parent) {
+        delegate.setParentClassLoader(parent);
+    }
+
+    @Override
+    public Catalina getCatalina() {
+        return delegate.getCatalina();
+    }
+
+    @Override
+    public void setCatalina(Catalina catalina) {
+        delegate.setCatalina(catalina);
+    }
+
+    @Override
+    public void addService(Service service) {
+        delegate.addService(service);
+    }
+
+    @Override
+    public void await() {
+        delegate.await();
+    }
+
+    @Override
+    public Service findService(String name) {
+        return delegate.findService(name);
+    }
+
+    @Override
+    public void removeService(Service service) {
+        delegate.removeService(service);
+    }
+
+    @Override
+    public void addLifecycleListener(LifecycleListener listener) {
+        delegate.addLifecycleListener(listener);
+    }
+
+    @Override
+    public LifecycleListener[] findLifecycleListeners() {
+        return delegate.findLifecycleListeners();
+    }
+
+    @Override
+    public void removeLifecycleListener(LifecycleListener listener) {
+        delegate.removeLifecycleListener(listener);
+    }
+
+    @Override
+    public void init() throws LifecycleException {
+        delegate.init();
+    }
+
+    @Override
+    public void start() throws LifecycleException {
+        delegate.start();
+    }
+
+    @Override
+    public void stop() throws LifecycleException {
+        delegate.stop();
+    }
+
+    @Override
+    public void destroy() throws LifecycleException {
+        delegate.destroy();
+    }
+
+    @Override
+    public LifecycleState getState() {
+        return delegate.getState();
+    }
+
+    @Override
+    public String getStateName() {
+        return delegate.getStateName();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ServiceFilteringDelegatingServer that = (ServiceFilteringDelegatingServer) o;
+
+        if (!Objects.equals(delegate, that.delegate)) return false;
+        return Objects.equals(serviceName, that.serviceName);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = delegate != null ? delegate.hashCode() : 0;
+        result = 31 * result + (serviceName != null ? serviceName.hashCode() : 0);
+        return result;
+    }
+}

--- a/container/tomcat/src/test/java/org/jboss/modcluster/container/tomcat/ContainerEventHandlerAdapterTestCase.java
+++ b/container/tomcat/src/test/java/org/jboss/modcluster/container/tomcat/ContainerEventHandlerAdapterTestCase.java
@@ -46,6 +46,7 @@ import org.mockito.Mockito;
 
 /**
  * @author Paul Ferraro
+ * @author Radoslav Husar
  */
 public class ContainerEventHandlerAdapterTestCase {
     protected final ContainerEventHandler eventHandler = mock(ContainerEventHandler.class);
@@ -268,7 +269,6 @@ public class ContainerEventHandlerAdapterTestCase {
         when(service.getServer()).thenReturn(server);
         when(this.factory.createContext(context)).thenReturn(catalinaContext);
 
-        // handler.lifecycleEvent(event);
         handler.propertyChange(prop);
 
         verify(this.eventHandler).start(same(catalinaContext));
@@ -319,6 +319,44 @@ public class ContainerEventHandlerAdapterTestCase {
     }
 
     @Test
+    public void initServerFromService() throws Exception {
+        TomcatEventHandler handler = this.createEventHandler(this.eventHandler, this.provider, this.factory);
+        LifecycleService service = mock(LifecycleService.class);
+
+        this.initServerFromService(handler, service);
+
+        handler.lifecycleEvent(this.createAfterInitEvent(service));
+
+        verifyNoInteractions(this.eventHandler);
+    }
+
+    protected void initServerFromService(TomcatEventHandler handler, LifecycleService service) {
+        org.apache.catalina.Server server = mock(org.apache.catalina.Server.class);
+        LifecycleEngine engine = mock(LifecycleEngine.class);
+        Container container = mock(Container.class);
+        LifecycleContainer childContainer = mock(LifecycleContainer.class);
+        Server catalinaServer = mock(Server.class);
+
+        when(service.getServer()).thenReturn(server);
+        when(service.getName()).thenReturn("Catalina");
+        when(server.findServices()).thenReturn(new Service[] { service });
+        when(service.getContainer()).thenReturn(engine);
+        when(engine.findChildren()).thenReturn(new Container[] { container });
+        when(container.findChildren()).thenReturn(new Container[] { childContainer });
+        when(this.factory.createServer(new ServiceFilteringDelegatingServer(service))).thenReturn(catalinaServer);
+
+        handler.lifecycleEvent(this.createAfterInitEvent(service));
+
+        verify(this.eventHandler).init(same(catalinaServer));
+        verify(engine).addContainerListener(handler);
+        verify(engine).addLifecycleListener(handler);
+        verify(container).addContainerListener(handler);
+        verify(childContainer).addLifecycleListener(handler);
+
+        reset(this.eventHandler);
+    }
+
+    @Test
     public void startServer() throws Exception {
         TomcatEventHandler handler = this.createEventHandler(this.eventHandler, this.provider, this.factory);
         LifecycleServer server = mock(LifecycleServer.class);
@@ -338,6 +376,31 @@ public class ContainerEventHandlerAdapterTestCase {
         when(this.factory.createServer(same(server))).thenReturn(catalinaServer);
 
         handler.lifecycleEvent(new LifecycleEvent(server, Lifecycle.AFTER_START_EVENT, null));
+
+        verify(this.eventHandler).start(same(catalinaServer));
+        reset(this.eventHandler);
+    }
+
+    @Test
+    public void startServerFromService() throws Exception {
+        TomcatEventHandler handler = this.createEventHandler(this.eventHandler, this.provider, this.factory);
+        LifecycleService service = mock(LifecycleService.class);
+
+        this.initServerFromService(handler, service);
+
+        this.startServerFromService(handler, service);
+
+        handler.lifecycleEvent(new LifecycleEvent(service, Lifecycle.AFTER_START_EVENT, null));
+
+        verifyNoInteractions(this.eventHandler);
+    }
+
+    protected void startServerFromService(TomcatEventHandler handler, LifecycleService service) {
+        Server catalinaServer = mock(Server.class);
+
+        when(this.factory.createServer(new ServiceFilteringDelegatingServer(service))).thenReturn(catalinaServer);
+
+        handler.lifecycleEvent(new LifecycleEvent(service, Lifecycle.AFTER_START_EVENT, null));
 
         verify(this.eventHandler).start(same(catalinaServer));
         reset(this.eventHandler);
@@ -411,6 +474,39 @@ public class ContainerEventHandlerAdapterTestCase {
     }
 
     @Test
+    public void stopServerFromService() throws Exception {
+        TomcatEventHandler handler = this.createEventHandler(this.eventHandler, this.provider, this.factory);
+
+        LifecycleService service = mock(LifecycleService.class);
+        LifecycleEvent event = new LifecycleEvent(service, Lifecycle.BEFORE_STOP_EVENT, null);
+
+        handler.lifecycleEvent(event);
+
+        verifyNoInteractions(this.eventHandler);
+
+        this.initServerFromService(handler, service);
+
+        handler.lifecycleEvent(event);
+
+        verifyNoInteractions(this.eventHandler);
+
+        this.startServerFromService(handler, service);
+
+        Server catalinaServer = mock(Server.class);
+
+        when(this.factory.createServer(new ServiceFilteringDelegatingServer(service))).thenReturn(catalinaServer);
+
+        handler.lifecycleEvent(event);
+
+        verify(this.eventHandler).stop(same(catalinaServer));
+        reset(this.eventHandler);
+
+        handler.lifecycleEvent(event);
+
+        verifyNoInteractions(this.eventHandler);
+    }
+
+    @Test
     public void destroyServer() throws Exception {
         TomcatEventHandler handler = this.createEventHandler(this.eventHandler, this.provider, this.factory);
 
@@ -424,6 +520,43 @@ public class ContainerEventHandlerAdapterTestCase {
         this.initServer(handler, server);
 
         Service service = mock(Service.class);
+        LifecycleEngine engine = mock(LifecycleEngine.class);
+        Container container = mock(Container.class);
+        LifecycleContainer childContainer = mock(LifecycleContainer.class);
+
+        when(server.findServices()).thenReturn(new Service[] { service });
+        when(service.getContainer()).thenReturn(engine);
+        when(engine.findChildren()).thenReturn(new Container[] { container });
+        when(container.findChildren()).thenReturn(new Container[] { childContainer });
+
+        handler.lifecycleEvent(event);
+
+        verify(engine).removeContainerListener(handler);
+        verify(engine).removeLifecycleListener(handler);
+        verify(container).removeContainerListener(handler);
+        verify(childContainer).removeLifecycleListener(handler);
+        verify(this.eventHandler).shutdown();
+        reset(this.eventHandler);
+
+        handler.lifecycleEvent(event);
+
+        verifyNoInteractions(this.eventHandler);
+    }
+
+    @Test
+    public void destroyServerFromService() throws Exception {
+        TomcatEventHandler handler = this.createEventHandler(this.eventHandler, this.provider, this.factory);
+
+        LifecycleService service = mock(LifecycleService.class);
+        org.apache.catalina.Server server = mock(org.apache.catalina.Server.class);
+        LifecycleEvent event = createBeforeDestroyInitEvent(service);
+
+        handler.lifecycleEvent(event);
+
+        verifyNoInteractions(this.eventHandler);
+
+        this.initServerFromService(handler, service);
+
         LifecycleEngine engine = mock(LifecycleEngine.class);
         Container container = mock(Container.class);
         LifecycleContainer childContainer = mock(LifecycleContainer.class);
@@ -485,6 +618,9 @@ public class ContainerEventHandlerAdapterTestCase {
     }
 
     protected interface LifecycleServer extends Lifecycle, org.apache.catalina.Server {
+    }
+
+    protected interface LifecycleService extends Lifecycle, org.apache.catalina.Service {
     }
 
     protected interface LifecycleEngine extends Lifecycle, org.apache.catalina.Engine {

--- a/container/tomcat100/src/test/java/org/jboss/modcluster/container/tomcat100/TomcatEventHandlerAdapterTestCase.java
+++ b/container/tomcat100/src/test/java/org/jboss/modcluster/container/tomcat100/TomcatEventHandlerAdapterTestCase.java
@@ -21,13 +21,6 @@
  */
 package org.jboss.modcluster.container.tomcat100;
 
-import static org.mockito.ArgumentMatchers.same;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
-
 import org.apache.catalina.Container;
 import org.apache.catalina.LifecycleEvent;
 import org.apache.catalina.LifecycleListener;
@@ -36,10 +29,21 @@ import org.jboss.modcluster.container.ContainerEventHandler;
 import org.jboss.modcluster.container.Server;
 import org.jboss.modcluster.container.tomcat.ContainerEventHandlerAdapterTestCase;
 import org.jboss.modcluster.container.tomcat.ServerProvider;
+import org.jboss.modcluster.container.tomcat.ServiceFilteringDelegatingServer;
 import org.jboss.modcluster.container.tomcat.TomcatEventHandler;
 import org.jboss.modcluster.container.tomcat.TomcatFactory;
+import org.junit.Test;
+
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 /**
+ * Needed to recompile due to: {@code java.lang.NoSuchMethodError: org.jboss.modcluster.container.tomcat.ContainerEventHandlerAdapterTestCase$LifecycleService.getContainer()Lorg/apache/catalina/Container;}
+ *
  * @author Radoslav Husar
  */
 public class TomcatEventHandlerAdapterTestCase extends ContainerEventHandlerAdapterTestCase {
@@ -74,6 +78,32 @@ public class TomcatEventHandlerAdapterTestCase extends ContainerEventHandlerAdap
         reset(this.eventHandler);
     }
 
+    @Override
+    protected void initServerFromService(TomcatEventHandler handler, LifecycleService service) {
+        org.apache.catalina.Server server = mock(org.apache.catalina.Server.class);
+        LifecycleEngine engine = mock(LifecycleEngine.class);
+        Container container = mock(Container.class);
+        LifecycleContainer childContainer = mock(LifecycleContainer.class);
+        Server catalinaServer = mock(Server.class);
+
+        when(service.getServer()).thenReturn(server);
+        when(service.getName()).thenReturn("Catalina");
+        when(server.findServices()).thenReturn(new Service[] { service });
+        when(service.getContainer()).thenReturn(engine);
+        when(engine.findChildren()).thenReturn(new Container[] { container });
+        when(container.findChildren()).thenReturn(new Container[] { childContainer });
+        when(this.factory.createServer(new ServiceFilteringDelegatingServer(service))).thenReturn(catalinaServer);
+
+        handler.lifecycleEvent(this.createAfterInitEvent(service));
+
+        verify(this.eventHandler).init(same(catalinaServer));
+        verify(engine).addContainerListener(handler);
+        verify(engine).addLifecycleListener(handler);
+        verify(container).addContainerListener(handler);
+        verify(childContainer).addLifecycleListener(handler);
+
+        reset(this.eventHandler);
+    }
 
     @Override
     public void start() {
@@ -152,6 +182,43 @@ public class TomcatEventHandlerAdapterTestCase extends ContainerEventHandlerAdap
         this.initServer(handler, server);
 
         Service service = mock(Service.class);
+        LifecycleEngine engine = mock(LifecycleEngine.class);
+        Container container = mock(Container.class);
+        LifecycleContainer childContainer = mock(LifecycleContainer.class);
+
+        when(server.findServices()).thenReturn(new Service[] { service });
+        when(service.getContainer()).thenReturn(engine);
+        when(engine.findChildren()).thenReturn(new Container[] { container });
+        when(container.findChildren()).thenReturn(new Container[] { childContainer });
+
+        handler.lifecycleEvent(event);
+
+        verify(engine).removeContainerListener(handler);
+        verify(engine).removeLifecycleListener(handler);
+        verify(container).removeContainerListener(handler);
+        verify(childContainer).removeLifecycleListener(handler);
+        verify(this.eventHandler).shutdown();
+        reset(this.eventHandler);
+
+        handler.lifecycleEvent(event);
+
+        verifyNoInteractions(this.eventHandler);
+    }
+
+    @Test
+    public void destroyServerFromService() throws Exception {
+        TomcatEventHandler handler = this.createEventHandler(this.eventHandler, this.provider, this.factory);
+
+        LifecycleService service = mock(LifecycleService.class);
+        org.apache.catalina.Server server = mock(org.apache.catalina.Server.class);
+        LifecycleEvent event = createBeforeDestroyInitEvent(service);
+
+        handler.lifecycleEvent(event);
+
+        verifyNoInteractions(this.eventHandler);
+
+        this.initServerFromService(handler, service);
+
         LifecycleEngine engine = mock(LifecycleEngine.class);
         Container container = mock(Container.class);
         LifecycleContainer childContainer = mock(LifecycleContainer.class);

--- a/container/tomcat85/src/test/java/org/jboss/modcluster/container/tomcat85/TomcatEventHandlerAdapterTestCase.java
+++ b/container/tomcat85/src/test/java/org/jboss/modcluster/container/tomcat85/TomcatEventHandlerAdapterTestCase.java
@@ -21,13 +21,6 @@
  */
 package org.jboss.modcluster.container.tomcat85;
 
-import static org.mockito.ArgumentMatchers.same;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
-
 import org.apache.catalina.Container;
 import org.apache.catalina.LifecycleEvent;
 import org.apache.catalina.LifecycleListener;
@@ -36,10 +29,21 @@ import org.jboss.modcluster.container.ContainerEventHandler;
 import org.jboss.modcluster.container.Server;
 import org.jboss.modcluster.container.tomcat.ContainerEventHandlerAdapterTestCase;
 import org.jboss.modcluster.container.tomcat.ServerProvider;
+import org.jboss.modcluster.container.tomcat.ServiceFilteringDelegatingServer;
 import org.jboss.modcluster.container.tomcat.TomcatEventHandler;
 import org.jboss.modcluster.container.tomcat.TomcatFactory;
+import org.junit.Test;
+
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 /**
+ * Needed to recompile due to: {@code java.lang.NoSuchMethodError: org.jboss.modcluster.container.tomcat.ContainerEventHandlerAdapterTestCase$LifecycleService.getContainer()Lorg/apache/catalina/Container;}
+ *
  * @author Paul Ferraro
  * @author Radoslav Husar
  */
@@ -47,7 +51,7 @@ public class TomcatEventHandlerAdapterTestCase extends ContainerEventHandlerAdap
 
     @Override
     protected TomcatEventHandler createEventHandler(ContainerEventHandler eventHandler, ServerProvider provider, TomcatFactory factory) {
-        return new org.jboss.modcluster.container.tomcat85.TomcatEventHandlerAdapter(eventHandler, provider, factory);
+        return new TomcatEventHandlerAdapter(eventHandler, provider, factory);
     }
 
     @Override
@@ -75,6 +79,32 @@ public class TomcatEventHandlerAdapterTestCase extends ContainerEventHandlerAdap
         reset(this.eventHandler);
     }
 
+    @Override
+    protected void initServerFromService(TomcatEventHandler handler, LifecycleService service) {
+        org.apache.catalina.Server server = mock(org.apache.catalina.Server.class);
+        LifecycleEngine engine = mock(LifecycleEngine.class);
+        Container container = mock(Container.class);
+        LifecycleContainer childContainer = mock(LifecycleContainer.class);
+        Server catalinaServer = mock(Server.class);
+
+        when(service.getServer()).thenReturn(server);
+        when(service.getName()).thenReturn("Catalina");
+        when(server.findServices()).thenReturn(new Service[] { service });
+        when(service.getContainer()).thenReturn(engine);
+        when(engine.findChildren()).thenReturn(new Container[] { container });
+        when(container.findChildren()).thenReturn(new Container[] { childContainer });
+        when(this.factory.createServer(new ServiceFilteringDelegatingServer(service))).thenReturn(catalinaServer);
+
+        handler.lifecycleEvent(this.createAfterInitEvent(service));
+
+        verify(this.eventHandler).init(same(catalinaServer));
+        verify(engine).addContainerListener(handler);
+        verify(engine).addLifecycleListener(handler);
+        verify(container).addContainerListener(handler);
+        verify(childContainer).addLifecycleListener(handler);
+
+        reset(this.eventHandler);
+    }
 
     @Override
     public void start() {
@@ -153,6 +183,43 @@ public class TomcatEventHandlerAdapterTestCase extends ContainerEventHandlerAdap
         this.initServer(handler, server);
 
         Service service = mock(Service.class);
+        LifecycleEngine engine = mock(LifecycleEngine.class);
+        Container container = mock(Container.class);
+        LifecycleContainer childContainer = mock(LifecycleContainer.class);
+
+        when(server.findServices()).thenReturn(new Service[] { service });
+        when(service.getContainer()).thenReturn(engine);
+        when(engine.findChildren()).thenReturn(new Container[] { container });
+        when(container.findChildren()).thenReturn(new Container[] { childContainer });
+
+        handler.lifecycleEvent(event);
+
+        verify(engine).removeContainerListener(handler);
+        verify(engine).removeLifecycleListener(handler);
+        verify(container).removeContainerListener(handler);
+        verify(childContainer).removeLifecycleListener(handler);
+        verify(this.eventHandler).shutdown();
+        reset(this.eventHandler);
+
+        handler.lifecycleEvent(event);
+
+        verifyNoInteractions(this.eventHandler);
+    }
+
+    @Test
+    public void destroyServerFromService() throws Exception {
+        TomcatEventHandler handler = this.createEventHandler(this.eventHandler, this.provider, this.factory);
+
+        LifecycleService service = mock(LifecycleService.class);
+        org.apache.catalina.Server server = mock(org.apache.catalina.Server.class);
+        LifecycleEvent event = createBeforeDestroyInitEvent(service);
+
+        handler.lifecycleEvent(event);
+
+        verifyNoInteractions(this.eventHandler);
+
+        this.initServerFromService(handler, service);
+
         LifecycleEngine engine = mock(LifecycleEngine.class);
         Container container = mock(Container.class);
         LifecycleContainer childContainer = mock(LifecycleContainer.class);


### PR DESCRIPTION
…vel rather than <Server> level

https://issues.redhat.com/browse/MODCLUSTER-720

The container even handler needs to handle sequence of events that are sent when the listener is on the <Service> level as opposed to only handling the chain of events on the <Server> level. The intention is to only register that service the listener is registered on thus a service stub that only filers that service is then passed around.