### PR TITLE
MODCLUSTER-743 Building using JDK 11 but running on JDK 8 yields java.lang.NoSuchMethodError: java.nio.ByteBuffer.flip()Ljava/nio/ByteBuffer; + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,14 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        java: [ 11, 17 ]
+        java: [ 8, 11, 17 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v1
         with:
-          java-version: ${{ matrix.java }}
+          java-version: 11
       - name: Cache local Maven repository
         uses: actions/cache@v2
         with:
@@ -27,5 +27,12 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - name: Build with Maven
-        run: mvn -B verify
+      - name: Build with Maven using JDK 11
+        run: mvn -B verify -DskipTests
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Run test with Maven using JDK ${{ matrix.java }}
+        # In order to support Windows Powershell, a space between -D property=true is required.
+        run: mvn -B verify -D enforcer.skip=true -D maven.main.skip=true

--- a/core/src/main/java/org/jboss/modcluster/advertise/impl/AdvertiseListenerImpl.java
+++ b/core/src/main/java/org/jboss/modcluster/advertise/impl/AdvertiseListenerImpl.java
@@ -26,6 +26,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
 import java.net.StandardSocketOptions;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.DatagramChannel;
@@ -234,7 +235,7 @@ public class AdvertiseListenerImpl implements AdvertiseListener {
             while (true) {
                 try {
                     channel.receive(buffer);
-                    buffer.flip();
+                    flipBuffer(buffer);
 
                     String message = new String(buffer.array(), 0, buffer.remaining(), DEFAULT_ENCODING);
 
@@ -328,9 +329,28 @@ public class AdvertiseListenerImpl implements AdvertiseListener {
                         Thread.yield();
                     }
                 } finally {
-                    buffer.clear();
+                    clearBuffer(buffer);
                 }
             }
         }
     }
+
+    /**
+     * JDK-compatible flip operating on {@link Buffer} instead of {@link ByteBuffer}. See MODCLUSTER-743.
+     *
+     * @param buffer a buffer to flip
+     */
+    public static void flipBuffer(Buffer buffer) {
+        buffer.flip();
+    }
+
+    /**
+     * JDK-compatible clear operating on {@link Buffer} instead of {@link ByteBuffer}. See MODCLUSTER-743.
+     *
+     * @param buffer a buffer to clear
+     */
+    public static void clearBuffer(Buffer buffer) {
+        buffer.clear();
+    }
+
 }

--- a/core/src/test/java/org/jboss/modcluster/advertise/impl/AdvertiseListenerImplTestCase.java
+++ b/core/src/test/java/org/jboss/modcluster/advertise/impl/AdvertiseListenerImplTestCase.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.modcluster.advertise.impl;
 
+import static org.jboss.modcluster.advertise.impl.AdvertiseListenerImpl.clearBuffer;
+import static org.jboss.modcluster.advertise.impl.AdvertiseListenerImpl.flipBuffer;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
@@ -95,10 +97,10 @@ public class AdvertiseListenerImplTestCase {
 
             ByteBuffer buffer = ByteBuffer.allocate(512);
             buffer.put(TestUtils.generateAdvertisePacketData(new Date(), 0, SERVER1, SERVER1_ADDRESS));
-            buffer.flip();
+            flipBuffer(buffer);
 
             sendChannel.send(buffer, config.getAdvertiseSocketAddress());
-            buffer.flip();
+            flipBuffer(buffer);
 
             verify(this.mcmpHandler, timeout(TIMEOUT)).addProxy(capturedSocketAddress.capture());
             reset(this.mcmpHandler);
@@ -108,12 +110,12 @@ public class AdvertiseListenerImplTestCase {
             assertEquals(SERVER_PORT, socketAddress.getPort());
 
             capturedSocketAddress = ArgumentCaptor.forClass(ProxyConfiguration.class);
-            buffer.clear();
+            clearBuffer(buffer);
             buffer.put(TestUtils.generateAdvertisePacketData(new Date(), 1, SERVER2, SERVER2_ADDRESS));
-            buffer.flip();
+            flipBuffer(buffer);
 
             sendChannel.send(buffer, config.getAdvertiseSocketAddress());
-            buffer.flip();
+            flipBuffer(buffer);
 
             verify(this.mcmpHandler, timeout(TIMEOUT)).addProxy(capturedSocketAddress.capture());
             reset(this.mcmpHandler);

--- a/core/src/test/java/org/jboss/modcluster/advertise/impl/DatagramChannelFactoryImplTestCase.java
+++ b/core/src/test/java/org/jboss/modcluster/advertise/impl/DatagramChannelFactoryImplTestCase.java
@@ -22,6 +22,8 @@
 
 package org.jboss.modcluster.advertise.impl;
 
+import static org.jboss.modcluster.advertise.impl.AdvertiseListenerImpl.flipBuffer;
+
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -93,7 +95,7 @@ public class DatagramChannelFactoryImplTestCase {
 
             ByteBuffer sendBuffer = ByteBuffer.allocate(256);
             sendBuffer.put(stringData);
-            sendBuffer.flip();
+            flipBuffer(sendBuffer);
 
             InetSocketAddress group = new InetSocketAddress(sendAddress, PORT);
             sendChannel.send(sendBuffer, group);
@@ -118,7 +120,7 @@ public class DatagramChannelFactoryImplTestCase {
                 ByteBuffer receiveBuffer = ByteBuffer.allocate(256);
 
                 receiveChannel.receive(receiveBuffer);
-                receiveBuffer.flip();
+                flipBuffer(receiveBuffer);
 
                 byte[] packetData = new byte[receiveBuffer.remaining()];
                 receiveBuffer.get(packetData);


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/MODCLUSTER-742
https://issues.redhat.com/browse/MODCLUSTER-743