### PR TITLE
MODCLUSTER-746 Creating an IPv4 multicast socket on Windows while jav…

### DIFF
--- a/core/src/main/java/org/jboss/modcluster/ModClusterService.java
+++ b/core/src/main/java/org/jboss/modcluster/ModClusterService.java
@@ -21,7 +21,6 @@
  */
 package org.jboss.modcluster;
 
-import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -160,7 +159,7 @@ public class ModClusterService implements ModClusterServiceMBean, ContainerEvent
         if (Boolean.TRUE.equals(advertise) || (advertise == null && this.mcmpConfig.getProxyConfigurations().isEmpty())) {
             try {
                 this.advertiseListener = this.listenerFactory.createListener(this.mcmpHandler, this.advertiseConfig);
-            } catch (IOException e) {
+            } catch (Throwable e) {
                 ModClusterLogger.LOGGER.advertiseStartFailed(e);
             }
         }
@@ -194,7 +193,7 @@ public class ModClusterService implements ModClusterServiceMBean, ContainerEvent
         if (this.advertiseListener != null) {
             try {
                 this.advertiseListener.close();
-            } catch (IOException e) {
+            } catch (Throwable e) {
                 ModClusterLogger.LOGGER.catchingDebug(e);
             }
 


### PR DESCRIPTION
…a.net.preferIPv6Addresses=true can throw UnsupportedAddressTypeException

https://issues.redhat.com/browse/MODCLUSTER-746