### PR TITLE
MODCLUSTER-743 Allow JDK8 by the enforcer if only used for running th…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,4 @@ jobs:
           java-version: ${{ matrix.java-runtime }}
       - name: Run test with Maven using JDK ${{ matrix.java-runtime }}
         # In order to support Windows Powershell, a space between -D property=true is required.
-        run: mvn -B verify -D enforcer.skip=true -D maven.main.skip=true
+        run: mvn -B verify -D maven.main.skip=true

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,23 @@
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
     </properties>
 
+    <profiles>
+        <profile>
+            <!-- Profile that configures enforcer plugin to allow JDK 8 only for running tests -->
+            <!-- Required since the main build requires JDK 11 for compilation -->
+            <id>jdk8-test-only</id>
+            <activation>
+                <property>
+                    <name>maven.main.skip</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <jdk.min.version>1.8</jdk.min.version>
+            </properties>
+        </profile>
+    </profiles>
+
     <dependencyManagement>
         <dependencies>
             <dependency>


### PR DESCRIPTION
…e test; keep requiring JDK11 for build
