### PR TITLE
MODCLUSTER-763 CI: Add JDK 19 Early-Access to the matrix compilation …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        java-compilation: [ 11, 17 ]
-        java-runtime: [ 8, 11, 17 ]
+        java-compilation: [ 11, 17, 19-ea ]
+        java-runtime: [ 8, 11, 17, 19-ea ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
…and runtime.

Resolves
https://issues.redhat.com/browse/MODCLUSTER-763