### PR TITLE
MODCLUSTER-772 Require JDK 11 as a minimum for the runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,17 +12,16 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        java-compilation: [ 11, 17, 19, 20-ea ]
         # Keep this list as: all supported LTS JDKs, the latest GA JDK, and the latest EA JDK.
-        java-runtime: [ 8, 11, 17, 19, 20-ea ]
+        java: [ 11, 17, 19, 20-ea ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set up JDK ${{ matrix.java-compilation }}
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v3.6.0
         with:
           distribution: temurin
-          java-version: ${{ matrix.java-compilation }}
+          java-version: ${{ matrix.java }}
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:
@@ -30,13 +29,5 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - name: Build with Maven using JDK ${{ matrix.java-compilation }}
-        run: mvn -B verify -DskipTests
-      - name: Set up JDK ${{ matrix.java-runtime }}
-        uses: actions/setup-java@v3.6.0
-        with:
-          distribution: temurin
-          java-version: ${{ matrix.java-runtime }}
-      - name: Run test with Maven using JDK ${{ matrix.java-runtime }}
-        # In order to support Windows Powershell, a space between -D property=true is required.
-        run: mvn -B verify -D maven.main.skip=true
+      - name: Build with Maven using JDK ${{ matrix.java }}
+        run: mvn -B verify

--- a/pom.xml
+++ b/pom.xml
@@ -61,9 +61,9 @@
     </modules>
 
     <properties>
-        <!-- Require JDK 11 and build for 8 -->
+        <!-- Require and build for JDK 11 -->
         <jdk.min.version>11</jdk.min.version>
-        <jdk.release.version>8</jdk.release.version>
+        <jdk.release.version>11</jdk.release.version>
 
         <!-- Common dependency -->
         <version.jboss-logging>3.4.3.Final</version.jboss-logging>
@@ -83,20 +83,6 @@
     </properties>
 
     <profiles>
-        <profile>
-            <!-- Profile that configures enforcer plugin to allow JDK 8 only for running tests -->
-            <!-- Required since the main build requires JDK 11 for compilation -->
-            <id>jdk8-test-only</id>
-            <activation>
-                <property>
-                    <name>maven.main.skip</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <properties>
-                <jdk.min.version>1.8</jdk.min.version>
-            </properties>
-        </profile>
         <!-- Code coverage report using JaCoCo -->
         <profile>
             <id>coverage</id>


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/MODCLUSTER-772