### PR TITLE
MODCLUSTER-784 Require JDK 17 as a minimum for the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,16 +12,16 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        # Keep this list as: all supported LTS JDKs, the latest GA JDK, and the latest EA JDK (if available).
-        java: [ 11, 17, 20 ]
+        java-compilation: [ 17, 20 ]
+        java-runtime: [ 11, 17, 20 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set up JDK ${{ matrix.java }}
+      - name: Set up JDK ${{ matrix.java-compilation }} (compilation)
         uses: actions/setup-java@v3.11.0
         with:
           distribution: temurin
-          java-version: ${{ matrix.java }}
+          java-version: ${{ matrix.java-compilation }}
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:
@@ -29,5 +29,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - name: Build with Maven using JDK ${{ matrix.java }}
-        run: mvn -B verify
+      - name: Build with Maven using JDK ${{ matrix.java-compilation }}
+        run: mvn -B verify -DskipTests
+      - name: Set up JDK ${{ matrix.java-runtime }} (runtime)
+        uses: actions/setup-java@v3.6.0
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java-runtime }}
+      - name: Run tests with Maven using JDK ${{ matrix.java-runtime }}
+        # In order to support Windows Powershell, a space between -D property=true is required.
+        run: mvn -B verify -D maven.main.skip=true

--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,8 @@
     </modules>
 
     <properties>
-        <!-- Require and build for JDK 11 -->
-        <jdk.min.version>11</jdk.min.version>
+        <!-- Require JDK 17 and build for JDK 11 -->
+        <jdk.min.version>17</jdk.min.version>
         <jdk.release.version>11</jdk.release.version>
 
         <!-- Common dependency -->
@@ -83,6 +83,20 @@
     </properties>
 
     <profiles>
+        <!-- Profile that configures enforcer plugin to allow JDK 11 solely for running tests -->
+        <!-- Required since the main build requires JDK 17 for the compilation -->
+        <profile>
+            <id>jdk11-test-only</id>
+            <activation>
+                <property>
+                    <name>maven.main.skip</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <jdk.min.version>11</jdk.min.version>
+            </properties>
+        </profile>
         <!-- Code coverage report using JaCoCo -->
         <profile>
             <id>coverage</id>


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/MODCLUSTER-784

TLDR: 

> In order to support Tomcat 11, we need to build at least with JDK 17 (class file 61).

