### PR TITLE
MODCLUSTER-789 Remove wrongly placed <goals> tag to enable Maven 4.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,9 +233,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <goals>
-                    <goal>compile</goal>
-                </goals>
                 <executions>
                     <execution>
                         <id>default-compile</id>


### PR DESCRIPTION
https://issues.redhat.com/browse/MODCLUSTER-789