### PR TITLE
MODCLUSTER-798 Fix handling of offseted ports

### DIFF
--- a/container/tomcat-8.5/src/main/java/org/jboss/modcluster/container/tomcat/SingleServiceServer.java
+++ b/container/tomcat-8.5/src/main/java/org/jboss/modcluster/container/tomcat/SingleServiceServer.java
@@ -100,7 +100,7 @@ public class SingleServiceServer implements Server {
 
     @Override
     public int getPortWithOffset() {
-        return this.service.getServer().getPort();
+        return this.service.getServer().getPortWithOffset();
     }
 
     @Override

--- a/container/tomcat-8.5/src/main/java/org/jboss/modcluster/container/tomcat/TomcatConnector.java
+++ b/container/tomcat-8.5/src/main/java/org/jboss/modcluster/container/tomcat/TomcatConnector.java
@@ -95,7 +95,7 @@ public class TomcatConnector implements Connector {
 
     @Override
     public int getPort() {
-        return (this.externalPort == null) ? this.connector.getPort() : this.externalPort;
+        return (this.externalPort == null) ? this.connector.getPortWithOffset() : this.externalPort;
     }
 
     @Override

--- a/container/tomcat-9.0/src/main/java/org/jboss/modcluster/container/tomcat/TomcatConnector.java
+++ b/container/tomcat-9.0/src/main/java/org/jboss/modcluster/container/tomcat/TomcatConnector.java
@@ -95,7 +95,7 @@ public class TomcatConnector implements Connector {
 
     @Override
     public int getPort() {
-        return (this.externalPort == null) ? this.connector.getPort() : this.externalPort;
+        return (this.externalPort == null) ? this.connector.getPortWithOffset() : this.externalPort;
     }
 
     @Override


### PR DESCRIPTION
https://issues.redhat.com/browse/MODCLUSTER-798

This PR makes it work when portOffset for tomcats 8.5 and 9.0. No fix is required for tomcat-10.1 which seems strange, however, I was not able to determine why tomcat-10.1 behaves differently. Because of this I believe the fix can be made better by someone who understand the codebase better.

This is the `server.xml` I used

```.xml
<?xml version="1.0" encoding="UTF-8"?>
<Server port="8005" shutdown="SHUTDOWN" address="127.0.0.1" portOffset="port_offset">
  <Listener className="org.jboss.modcluster.container.catalina.standalone.ModClusterListener"
              connectorPort="8080"
              advertise="false"
              stickySession="true"
              stickySessionForce="false"
              stickySessionRemove="true"
              proxyList="127.0.0.1:6666" />
  <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
  <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
  <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
  <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
  <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />

  <GlobalNamingResources>
    <Resource name="UserDatabase" auth="Container"
              type="org.apache.catalina.UserDatabase"
              description="User database that can be updated and saved"
              factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
              pathname="conf/tomcat-users.xml" />
  </GlobalNamingResources>

  <Service name="Catalina">
    <Connector port="8080" protocol="HTTP/1.1"
               address="127.0.0.1"
               connectionTimeout="20000"
               redirectPort="8443"
               portOffset="port_offset" />
    
    <Connector protocol="AJP/1.3"
               address="127.0.0.1"
               port="8009"
               secretRequired="false"
               redirectPort="8443"
               portOffset="port_offset" />
   
    <Engine name="Catalina" defaultHost="localhost">

      <Realm className="org.apache.catalina.realm.LockOutRealm">
        <Realm className="org.apache.catalina.realm.UserDatabaseRealm"
               resourceName="UserDatabase"/>
      </Realm>

      <Host name="localhost"  appBase="webapps"
            unpackWARs="true" autoDeploy="true">

        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
               prefix="localhost_access_log" suffix=".txt"
               pattern="%h %l %u %t &quot;%r&quot; %s %b" />
      </Host>
    </Engine>
  </Service>
</Server>
```

with `tomcat1` running on `127.0.0.1:8080` (offset `0`) and `tomcat2` on `127.0.0.1:8081` (offset `1`). Without these changes, proxy gets `CONFIG` message for `tomcat2` with port `8080`. Alternatively, I could change `connectorPort` for `tomcat2` to `8081`, but that would cause some issues in `createProxyConnector` function (e.g., `connectorPort.equals(connector.getPort())`).

Edit: Fix formatting.