### PR TITLE
MODCLUSTER-812 Configure jboss-logging annotation processing via maven-compiler-plugin's annotationProcessorPaths + add JDK 22-ea support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,14 @@ jobs:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
         # Keep this list as: all supported LTS JDKs, the latest GA JDK, and the latest EA JDK (if available).
-        java: [ 11, 17, 21 ]
+        java: [ 11, 17, 21, 22-ea ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:
-          # Use 'oracle' distribution for JDK 21 until 'temurin' is available.
-          distribution: ${{ matrix.java == 21 && 'oracle' || 'temurin' }}
+          distribution: temurin
           java-version: ${{ matrix.java }}
       - name: Cache local Maven repository
         uses: actions/cache@v3

--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,18 @@
                         </goals>
                         <configuration>
                             <release>${jdk.release.version}</release>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>org.jboss.logging</groupId>
+                                    <artifactId>jboss-logging-processor</artifactId>
+                                    <version>${version.jboss-logging-processor}</version>
+                                </path>
+                                <path>
+                                    <groupId>org.jboss.logging</groupId>
+                                    <artifactId>jboss-logging</artifactId>
+                                    <version>${version.jboss-logging}</version>
+                                </path>
+                            </annotationProcessorPaths>
                         </configuration>
                     </execution>
                 </executions>
@@ -252,7 +264,7 @@
                         <failsOnError>true</failsOnError>
                         <includeTestSourceDirectory>true</includeTestSourceDirectory>
                         <excludes>**/*$logger.java,**/*$bundle.java</excludes>
-                        <useFile />
+                        <useFile/>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/MODCLUSTER-812

and adds JDK 22-ea support.

Replaces https://github.com/modcluster/mod_cluster/pull/757