### PR TITLE
MODCLUSTER-795 Publish JaCoCo code coverage reports through CI pipeline + MODCLUSTER-814 Missing code-coverage report for Tomcat 10.1 integration module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,5 +29,11 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - name: Build with Maven using JDK ${{ matrix.java }}
-        run: mvn -B verify
+      - name: Build (with coverage) with Maven using JDK ${{ matrix.java }}
+        run: mvn -B verify -P coverage
+      - name: Upload JaCoCo report
+        uses: actions/upload-artifact@v2
+        if: ${{ matrix.java == '11' && matrix.os == 'ubuntu-latest' }}
+        with:
+          name: jacoco
+          path: code-coverage/target/site/jacoco-aggregate

--- a/code-coverage/pom.xml
+++ b/code-coverage/pom.xml
@@ -57,6 +57,13 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/code-coverage/pom.xml
+++ b/code-coverage/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.jboss.mod_cluster</groupId>
         <artifactId>mod_cluster-parent</artifactId>
-        <version>2.0.2.Final-SNAPSHOT</version>
+        <version>2.0.5.Final-SNAPSHOT</version>
     </parent>
 
     <artifactId>mod_cluster-code-coverage-jacoco</artifactId>

--- a/code-coverage/pom.xml
+++ b/code-coverage/pom.xml
@@ -30,6 +30,10 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.mod_cluster</groupId>
+            <artifactId>mod_cluster-container-tomcat-10.1</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.mod_cluster</groupId>
             <artifactId>mod_cluster-core</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,13 @@
                 </plugins>
             </build>
         </profile>
+        <!-- Include the code-coverage module during release to keep module versions synchronized -->
+        <profile>
+            <id>jboss-release</id>
+            <modules>
+                <module>code-coverage</module>
+            </modules>
+        </profile>
     </profiles>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,11 @@
             </dependency>
             <dependency>
                 <groupId>org.jboss.mod_cluster</groupId>
+                <artifactId>mod_cluster-container-tomcat-10.1</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.mod_cluster</groupId>
                 <artifactId>mod_cluster-core</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/MODCLUSTER-795
https://issues.redhat.com/browse/MODCLUSTER-814