### PR TITLE
[1.3] MODCLUSTER-817 Update Maven SCM connection/developerConnection to use…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
     </licenses>
 
     <scm>
-        <connection>scm:git:https://github.com/modcluster/mod_cluster.git</connection>
-        <developerConnection>scm:git:https://github.com/modcluster/mod_cluster.git</developerConnection>
+        <connection>scm:git:git@github.com:modcluster/mod_cluster.git</connection>
+        <developerConnection>scm:git:git@github.com:modcluster/mod_cluster.git</developerConnection>
         <url>https://github.com/modcluster/mod_cluster</url>
         <tag>HEAD</tag>
     </scm>


### PR DESCRIPTION
… git: instead of no longer supported https://

https://issues.redhat.com/browse/MODCLUSTER-817