### PR TITLE
MODCLUSTER-837 CI: Add Javadoc aggregate build to the testing pipeline + MODCLUSTER-836 Building the aggregate Javadoc site fails the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,15 +39,25 @@ jobs:
           distribution: temurin
           java-version: ${{ matrix.java-runtime }}
       - name: Build with Maven using JDK ${{ matrix.java-runtime }}
-        # To support Windows PowerShell, a space between -D property=true is required.
-        run: mvn --batch-mode --no-transfer-progress verify --define net.bytebuddy.experimental=true --define maven.main.skip=true
+        # To support Windows PowerShell, a space between --define property=true is required.
+        run: mvn --batch-mode --no-transfer-progress --define net.bytebuddy.experimental=true --define maven.main.skip=true verify
       # Code Coverage (runs once per matrix)
       - name: Build with coverage with Maven using JDK ${{ matrix.runtime }}
         if: ${{ matrix.java-compilation == '17' && matrix.java-runtime == '11' && matrix.os == 'ubuntu-latest' }}
-        run: mvn --batch-mode --no-transfer-progress --activate-profiles=coverage verify --define maven.main.skip=true
+        run: mvn --batch-mode --no-transfer-progress --activate-profiles=coverage --define maven.main.skip=true verify
       - name: Upload JaCoCo report
         if: ${{ matrix.java-compilation == '17' && matrix.java-runtime == '11' && matrix.os == 'ubuntu-latest' }}
         uses: actions/upload-artifact@v4
         with:
           name: jacoco
-          path: code-coverage/target/site/jacoco-aggregate
+          path: code-coverage/target/site/jacoco-aggregate/
+      # Aggregate Javadoc (runs once per matrix)
+      - name: Build aggregate Javadoc with Maven using JDK ${{ matrix.runtime }}
+        if: ${{ matrix.java-compilation == '17' && matrix.java-runtime == '17' && matrix.os == 'ubuntu-latest' }}
+        run: mvn --batch-mode --no-transfer-progress --define skipTests=true verify javadoc:aggregate
+      - name: Upload aggregate Javadoc
+        if: ${{ matrix.java-compilation == '17' && matrix.java-runtime == '17' && matrix.os == 'ubuntu-latest' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: apidocs
+          path: target/site/apidocs/

--- a/pom.xml
+++ b/pom.xml
@@ -232,15 +232,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <!-- Workaround for compiling on JDK11 -->
-                    <!-- ModClusterLogger_$logger.java:6: error: package javax.annotation does not exist; for @Generated -->
-                    <additionalDependencies>
-                        <additionalDependency>
-                            <groupId>javax.annotation</groupId>
-                            <artifactId>javax.annotation-api</artifactId>
-                            <version>1.3.2</version>
-                        </additionalDependency>
-                    </additionalDependencies>
+                    <!-- The Tomcat container integration modules use the *same* package and class names which are not discerned by an aggregate Javadoc report.
+                         Thus, the following skippedModules should be a comma separated list of all non-latest Tomcat modules (artifactId) to not add in aggregated Javadoc.
+                         See https://maven.apache.org/plugins/maven-javadoc-plugin/javadoc-mojo.html#skippedModules -->
+                    <skippedModules>mod_cluster-container-tomcat-9.0,mod_cluster-container-tomcat-10.1</skippedModules>
                     <source>${jdk.release.version}</source>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/MODCLUSTER-837
https://issues.redhat.com/browse/MODCLUSTER-836