### PR TITLE
MODCLUSTER-845 Update deprecated getMessageLogger(..) and getBundle(.…

### DIFF
--- a/core/src/main/java/org/jboss/modcluster/ModClusterLogger.java
+++ b/core/src/main/java/org/jboss/modcluster/ModClusterLogger.java
@@ -4,8 +4,12 @@
  */
 package org.jboss.modcluster;
 
-import static org.jboss.logging.Logger.Level.*;
+import static org.jboss.logging.Logger.Level.DEBUG;
+import static org.jboss.logging.Logger.Level.ERROR;
+import static org.jboss.logging.Logger.Level.INFO;
+import static org.jboss.logging.Logger.Level.WARN;
 
+import java.lang.invoke.MethodHandles;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 
@@ -24,7 +28,7 @@ import org.jboss.modcluster.mcmp.MCMPRequestType;
  */
 @MessageLogger(projectCode = "MODCLUSTER")
 public interface ModClusterLogger {
-    ModClusterLogger LOGGER = Logger.getMessageLogger(ModClusterLogger.class, ModClusterLogger.class.getPackage().getName());
+    ModClusterLogger LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), ModClusterLogger.class, ModClusterLogger.class.getPackage().getName());
 
     String CATCHING_MARKER = "Catching";
 

--- a/core/src/main/java/org/jboss/modcluster/ModClusterMessages.java
+++ b/core/src/main/java/org/jboss/modcluster/ModClusterMessages.java
@@ -4,6 +4,7 @@
  */
 package org.jboss.modcluster;
 
+import java.lang.invoke.MethodHandles;
 import java.security.cert.CRLException;
 
 import org.jboss.logging.Messages;
@@ -16,7 +17,7 @@ import org.jboss.modcluster.container.Host;
  */
 @MessageBundle(projectCode = "MODCLUSTER")
 public interface ModClusterMessages {
-    ModClusterMessages MESSAGES = Messages.getBundle(ModClusterMessages.class);
+    ModClusterMessages MESSAGES = Messages.getBundle(MethodHandles.lookup(), ModClusterMessages.class);
 
     @Message(id = 100, value = "Unable to locate host %s")
     IllegalArgumentException hostNotFound(String host);


### PR DESCRIPTION
….) methods usage

Resolves
https://issues.redhat.com/browse/MODCLUSTER-845