### PR TITLE
MODCLUSTER-848 Move to Java SE 17 as the minimum SE version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,52 +12,37 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        # Keep this list as: all supported >= 17 LTS JDKs
-        java-compilation: [ 17, 21 ]
         # Keep this list as: all supported LTS JDKs, the latest GA JDK, and optionally the latest EA JDK (if available).
         # https://www.oracle.com/java/technologies/java-se-support-roadmap.html
-        java: [ 11, 17, 21, 23 ]
+        java: [ 17, 21, 23 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up JDK ${{ matrix.java-compilation }} (compilation)
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: ${{ matrix.java-compilation }}
-      - name: Build with Maven using JDK ${{ matrix.java-compilation }} (compilation only)
-        run: mvn --batch-mode --no-transfer-progress verify --define skipTests=true
-      - name: Cache local Maven repository
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - name: Set up JDK ${{ matrix.java }} (runtime)
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
-      - name: Build with Maven using JDK ${{ matrix.java }}
+          cache: maven
+      - name: Build with Maven
         # To support Windows PowerShell, a space between --define property=true is required.
-        run: mvn --batch-mode --no-transfer-progress --define maven.main.skip=true verify
+        run: ./mvnw --batch-mode --no-transfer-progress verify
       # Code Coverage (runs once per matrix)
-      - name: Build with coverage with Maven using JDK ${{ matrix.runtime }}
-        if: ${{ matrix.java-compilation == '17' && matrix.java == '11' && matrix.os == 'ubuntu-latest' }}
-        run: mvn --batch-mode --no-transfer-progress --activate-profiles=coverage --define maven.main.skip=true verify
+      - name: Build with coverage with Maven using JDK ${{ matrix.java }}
+        if: ${{ matrix.java == '17' && matrix.os == 'ubuntu-latest' }}
+        run: ./mvnw --batch-mode --no-transfer-progress --activate-profiles=coverage verify
       - name: Upload JaCoCo report
-        if: ${{ matrix.java-compilation == '17' && matrix.java == '11' && matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.java == '17' && matrix.os == 'ubuntu-latest' }}
         uses: actions/upload-artifact@v4
         with:
           name: jacoco
           path: code-coverage/target/site/jacoco-aggregate/
       # Aggregate Javadoc (runs once per matrix)
-      - name: Build aggregate Javadoc with Maven using JDK ${{ matrix.runtime }}
-        if: ${{ matrix.java-compilation == '17' && matrix.java == '17' && matrix.os == 'ubuntu-latest' }}
-        run: mvn --batch-mode --no-transfer-progress --define skipTests=true verify javadoc:aggregate
+      - name: Build aggregate Javadoc with Maven using JDK ${{ matrix.java }}
+        if: ${{ matrix.java == '17' && matrix.os == 'ubuntu-latest' }}
+        run: ./mvnw --batch-mode --no-transfer-progress --define skipTests=true verify javadoc:aggregate
       - name: Upload aggregate Javadoc
-        if: ${{ matrix.java-compilation == '17' && matrix.java == '17' && matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.java == '17' && matrix.os == 'ubuntu-latest' }}
         uses: actions/upload-artifact@v4
         with:
           name: apidocs

--- a/container/tomcat-11.0/pom.xml
+++ b/container/tomcat-11.0/pom.xml
@@ -46,25 +46,4 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
-
-    <profiles>
-        <profile>
-            <id>jdk11-skip-tests</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -43,9 +43,8 @@
     </modules>
 
     <properties>
-        <!-- Require JDK 17 and build for JDK 11 -->
-        <jdk.min.version>17</jdk.min.version>
-        <jdk.release.version>11</jdk.release.version>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
 
         <!-- Common dependencies -->
         <version.jboss-logging>3.6.1.Final</version.jboss-logging>
@@ -62,20 +61,6 @@
     </properties>
 
     <profiles>
-        <!-- Profile that configures enforcer plugin to allow JDK 11 solely for running tests -->
-        <!-- Required since the main build requires JDK 17 for the compilation -->
-        <profile>
-            <id>jdk11-test-only</id>
-            <activation>
-                <property>
-                    <name>maven.main.skip</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <properties>
-                <jdk.min.version>11</jdk.min.version>
-            </properties>
-        </profile>
         <!-- Code coverage report using JaCoCo -->
         <profile>
             <id>coverage</id>
@@ -203,9 +188,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <release>${jdk.release.version}</release>
-                </configuration>
                 <executions>
                     <execution>
                         <id>default-compile</id>
@@ -238,7 +220,6 @@
                          Thus, the following skippedModules should be a comma separated list of all non-latest Tomcat modules (artifactId) to not add in aggregated Javadoc.
                          See https://maven.apache.org/plugins/maven-javadoc-plugin/javadoc-mojo.html#skippedModules -->
                     <skippedModules>mod_cluster-container-tomcat-9.0,mod_cluster-container-tomcat-10.1</skippedModules>
-                    <source>${jdk.release.version}</source>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
* Cleans up a lot of build cruft needed to support both 11/17 
* and significantly reduces required CI. 
* Uses maven-wrapper for deterministic builds.

Resolves
https://issues.redhat.com/browse/MODCLUSTER-848