### PR TITLE
MODCLUSTER-779 Remove or fix broken links in logs pointing to jboss.org

### DIFF
--- a/core/src/main/java/org/jboss/modcluster/ModClusterLogger.java
+++ b/core/src/main/java/org/jboss/modcluster/ModClusterLogger.java
@@ -118,7 +118,7 @@ public interface ModClusterLogger {
 //    void createMulticastSocketWithUnicastAddress(InetAddress address);
 
     @LogMessage(level = WARN)
-    @Message(id = 31, value = "Could not bind multicast socket to %s (%s address): %s; make sure your multicast address is of the same type as the IP stack (IPv4 or IPv6). Multicast socket will not be bound to an address, but this may lead to cross talking (see https://developer.jboss.org/docs/DOC-9469 for details).")
+    @Message(id = 31, value = "Could not bind multicast socket to %s (%s address): %s; make sure your multicast address is of the same type as the IP stack (IPv4 or IPv6). Multicast socket will not be bound to an address, but this may lead to crosstalking.")
     void potentialCrossTalking(InetAddress address, String addressType, String message);
 
     @LogMessage(level = INFO)

--- a/core/src/main/java/org/jboss/modcluster/advertise/impl/DatagramChannelFactoryImpl.java
+++ b/core/src/main/java/org/jboss/modcluster/advertise/impl/DatagramChannelFactoryImpl.java
@@ -22,7 +22,7 @@ import org.jboss.modcluster.advertise.DatagramChannelFactory;
 /**
  * On Linux-like systems, we attempt to avoid cross-talk problem by binding the DatagramChannel to the multicast
  * address, if possible. If not possible, default to binding only to the port. See
- * {@link <a href="https://issues.jboss.org/browse/JGRP-777">JGRP-777</a>}.
+ * {@link <a href="https://issues.redhat.com/browse/JGRP-777">JGRP-777</a>}.
  * <p>
  * On Windows-like systems, we do not attempt to bind the socket to the multicast address, we only bind to the port.
  * <p>

--- a/core/src/test/java/org/jboss/modcluster/advertise/impl/DatagramChannelFactoryImplTestCase.java
+++ b/core/src/test/java/org/jboss/modcluster/advertise/impl/DatagramChannelFactoryImplTestCase.java
@@ -48,9 +48,11 @@ public class DatagramChannelFactoryImplTestCase {
     }
 
     /**
-     * Verify that cross-talking problem does not happen any more.
+     * Verify that crosstalking problem does not happen anymore.
      *
-     * @see <a href="https://developer.jboss.org/wiki/CrossTalkingBetweenClustersWithSameMulticastPortsButDifferentMulticastAddresses">Cross-talking wiki</a>
+     * @see <a href="https://developer.jboss.org/docs/DOC-9469">Crosstalking between clusters with same multicast ports but different multicast addresses</a>
+     * @see <a href="https://issues.redhat.com/browse/JGRP-777">JGRP-777 Revisit multicast socket creation code</a>
+     * @see <a href="https://issues.redhat.com/browse/JGRP-836">JGRP-836 Eliminate Linux cross-talk in MPING</a>
      */
     @Test
     public void testDatagramChannelNoCrossTalking() throws Exception {


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/MODCLUSTER-779

Removes links to non-editable and honestly no longer relevant pages.