### PR TITLE
Update native version to mod_cluster/1.3.22.Final-SNAPSHOT

### DIFF
--- a/native/include/mod_proxy_cluster.h
+++ b/native/include/mod_proxy_cluster.h
@@ -28,7 +28,7 @@
 #ifndef MOD_PROXY_CLUSTER_H
 #define MOD_PROXY_CLUSTER_H
 
-#define MOD_CLUSTER_EXPOSED_VERSION "mod_cluster/1.3.22.Final"
+#define MOD_CLUSTER_EXPOSED_VERSION "mod_cluster/1.3.22.Final-SNAPSHOT"
 
 struct balancer_method {
 /**


### PR DESCRIPTION
We actually want to keep this aligned with the maven version to be able to differentiate native builds compiled from a snapshot rather than finalized versions. So, reverting back to the original versioning scheme.