### PR TITLE
MODCLUSTER-854 Fix compilation warnings with newer JDKs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,8 +44,10 @@
     </modules>
 
     <properties>
-        <maven.compiler.target>17</maven.compiler.target>
-        <maven.compiler.source>17</maven.compiler.source>
+        <!-- JBoss Parent -->
+        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
+        <maven.compiler.source>${maven.compiler.release}</maven.compiler.source>
 
         <!-- Common dependencies -->
         <version.jboss-logging>3.6.1.Final</version.jboss-logging>


### PR DESCRIPTION
https://issues.redhat.com/browse/MODCLUSTER-854

I just assumed that jboss-parent does this, but it does not currently set it the way we have set it up.