### PR TITLE
Add a few basic GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/ci.md
+++ b/.github/ISSUE_TEMPLATE/ci.md
@@ -1,0 +1,10 @@
+---
+name: "CI / GH Actions"
+about: Report an issue related to GH Actions
+title: "[CI]: "
+labels: "github_actions"
+assignees: "jajik, rhusar"
+---
+
+Thank you for opening an issue. Please replace this text and describe the issue you are facing.
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/java-mod_cluster.md
+++ b/.github/ISSUE_TEMPLATE/java-mod_cluster.md
@@ -1,0 +1,12 @@
+---
+name: Java module
+about: Report an issue with regard to the Java modules
+title: ""
+labels: java
+assignees: "rhusar"
+---
+
+Thank you for opening an issue. Please replace this text and describe the issue you are facing.
+
+Consider adding steps to reproduce and any information regarding your platform and the version (commit) you used.
+

--- a/.github/ISSUE_TEMPLATE/native-mod_proxy_cluster.md
+++ b/.github/ISSUE_TEMPLATE/native-mod_proxy_cluster.md
@@ -1,0 +1,12 @@
+---
+name: 1.3.x branch issue
+about: Report an issue with regard to the httpd module
+title: "[1.3.x]: "
+labels: 1.3.x
+assignees: "jajik"
+---
+
+Thank you for opening an issue. Please replace this text and describe the issue you are facing.
+
+Consider adding steps to reproduce and any information regarding your platform and the version (commit) you used.
+


### PR DESCRIPTION
I added only a few templates as it does not make sense to create templates for all possible combinations. It might be nice to have this for some basic triaging (until we move 1.3.x to the next repository, but maybe even then we could just update the template with a redirect info).