### PR TITLE
MODCLUSTER-860 CI: broken macos-latest during latest August rollout t…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-latest
+          - macos-14
           - ubuntu-latest
           - windows-latest
         # Keep this list as: all supported LTS JDKs, the latest GA JDK, and optionally the latest EA JDK (if available).


### PR DESCRIPTION
…o macOS 15

https://issues.redhat.com/browse/MODCLUSTER-860