### PR TITLE
MODCLUSTER-876 Drain pending proxies discovery in init() and reset established on shutdown

### DIFF
--- a/core/src/main/java/org/jboss/modcluster/ModClusterService.java
+++ b/core/src/main/java/org/jboss/modcluster/ModClusterService.java
@@ -184,6 +184,7 @@ public class ModClusterService implements ModClusterServiceMBean, ContainerEvent
         }
 
         this.mcmpHandler.shutdown();
+        this.established = false;
     }
 
     @Override

--- a/core/src/main/java/org/jboss/modcluster/mcmp/impl/DefaultMCMPHandler.java
+++ b/core/src/main/java/org/jboss/modcluster/mcmp/impl/DefaultMCMPHandler.java
@@ -119,6 +119,7 @@ public class DefaultMCMPHandler implements MCMPHandler {
                     this.add(proxy.getRemoteAddress(), proxy.getLocalAddress());
                 }
 
+                this.processPendingDiscoveryEvents();
                 this.status(false);
             } finally {
                 lock.unlock();
@@ -131,6 +132,7 @@ public class DefaultMCMPHandler implements MCMPHandler {
     @Override
     public void shutdown() {
         this.init = false;
+        this.established.set(false);
 
         Lock lock = this.proxiesLock.readLock();
         lock.lock();


### PR DESCRIPTION
The processPendingDiscoveryEvents() was inadvertently moved out of the private status(boolean) in MODCLUSTER-103, so init()'s status(false) iterates an empty proxy list and never establishes a connection. Restore the drain call before status(false) so statically configured proxies are contacted eagerly during init.

Also reset both established flags on shutdown so isEstablished() does not report a stale value after stop.

This would fix registration with the proxies in init.

https://redhat.atlassian.net/browse/MODCLUSTER-876